### PR TITLE
Disable CGO during release builds

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 go get -d ./...
-CGO_ENABLE=0 \
+CGO_ENABLED=0 \
 gox \
 -ldflags '-w -s' \
 -ldflags '-X main.version='"$BUILD_VERSION" \


### PR DESCRIPTION
## Summary
- Correct the build environment variable from `CGO_ENABLE` to `CGO_ENABLED`.
- Keep release builds configured for disabled CGO as intended.

## Verification
- `sh -n bin/build.sh`
- `go test ./...`
