### PR TITLE
Add shellcheck guard for scripts

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -27,6 +27,12 @@ jobs:
       - name: install dependencies
         run: go install
 
+      - name: install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: shellcheck
+        run: shellcheck bin/*.sh
+
       - name: lint
         run: |
           go vet ./...
@@ -34,4 +40,3 @@ jobs:
 
       - name: test
         run: go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
-

--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 outdir=$(mktemp -d)
 
-for pkg in '' ; do
-  go test \
-    -covermode=atomic \
-    -coverprofile="$outdir"/"$pkg".out \
-    ./"$pkg" \
-  > /dev/null
-done
-cat - - <<<'mode: atomic' <(tail -n +2 -q "$outdir"/.out) > coverage.out
+go test \
+	-covermode=atomic \
+	-coverprofile="$outdir"/coverage.out \
+	. \
+	>/dev/null
+cat - - <(tail -n +2 -q "$outdir"/*.out) <<<'mode: atomic' >coverage.out
 rm -rf "$outdir"


### PR DESCRIPTION
## Summary
- fix the coverage helper so ShellCheck no longer flags its package loop
- add a ShellCheck step to the existing Go CI workflow

## Verification
- shellcheck bin/*.sh
- go vet ./...
- go test -v ./...
- bash bin/coverage.sh