### PR TITLE
ci: guard docker release workflow for pull request context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.cmd_cache
+.cmd_cache_test
+.git
+.github
+.tmp
+build
+coverage.out

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -9,6 +12,8 @@ on:
 
 jobs:
   push_to_registry:
+    permissions:
+      contents: read
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
@@ -18,6 +23,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: github.event_name == 'release' && !github.event.release.prerelease
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -27,15 +33,27 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: kitsuyui/scraper
+          images: kitsuyui/cmd_cache
 
       - name: Build and push Docker image
+        id: publish
         uses: docker/build-push-action@v6
         if: github.event_name == 'release' && !github.event.release.prerelease
         with:
           context: .
           file: docker/server/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build Docker image (pull request check)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/server/Dockerfile
+          push: false
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /out/cmd_cache .
+
+FROM alpine:3.22
+
+COPY --from=build /out/cmd_cache /usr/local/bin/cmd_cache
+
+ENTRYPOINT ["cmd_cache"]


### PR DESCRIPTION
## Why
- `docker-release.yml` ran on both `pull_request` and `release` events and attempted Docker Hub login regardless of event type.
- The same workflow used `kitsuyui/scraper` in metadata, which does not match this repository.

## Changes
- Add workflow/job-level `permissions` to keep read-only paths explicit.
- Guard Docker Hub login to release publish path only (`release` and not prerelease).
- Split build behavior:
  - release publish: existing push flow kept, unchanged publish semantics.
  - pull_request: run `docker/build-push-action` with `push: false` as a build-only check.
- Update metadata image name from `kitsuyui/scraper` to `kitsuyui/cmd_cache`.

## Validation
- Syntax check: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-release.yml'); puts 'ok'`
- Command result: `ok`

## Notes
- Local `go test` could not run in this environment because `go` is not installed.
