### PR TITLE
fix: reject invalid cache status

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,17 +87,21 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer statusFile.Close()
 	exitStatusText, err := ioutil.ReadAll(statusFile)
 	if err != nil {
 		return 0, err
 	}
 	exitStatus, err := strconv.Atoi(string(exitStatusText))
+	if err != nil {
+		return 0, err
+	}
 	io.Copy(os.Stdout, outFile)
 	io.Copy(os.Stderr, errFile)
 	return exitStatus, nil
 }
 
-func (cc CommandCache) RunAndCache() int {
+func (cc CommandCache) RunAndCache() (int, error) {
 	outFile, err := os.OpenFile(cc.OutFilepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		log.Fatal(err)
@@ -108,11 +112,6 @@ func (cc CommandCache) RunAndCache() int {
 		log.Fatal(err)
 	}
 	defer errFile.Close()
-	statusFile, err := os.OpenFile(cc.StatusFilepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer statusFile.Close()
 	outWriter := io.MultiWriter(outFile, os.Stdout)
 	errWriter := io.MultiWriter(errFile, os.Stderr)
 
@@ -127,9 +126,18 @@ func (cc CommandCache) RunAndCache() int {
 		if s, ok := err2.Sys().(syscall.WaitStatus); ok {
 			exitStatus = s.ExitStatus()
 		}
+	} else if err != nil {
+		return 1, err
 	}
-	statusFile.Write([]byte(strconv.Itoa(exitStatus)))
-	return exitStatus
+	statusFile, err := os.OpenFile(cc.StatusFilepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return exitStatus, err
+	}
+	defer statusFile.Close()
+	if _, err := statusFile.Write([]byte(strconv.Itoa(exitStatus))); err != nil {
+		return exitStatus, err
+	}
+	return exitStatus, nil
 }
 
 var version string
@@ -174,7 +182,10 @@ func main() {
 	var exitStatus int
 	exitStatus, err = commandCache.ReplayByCache()
 	if err != nil {
-		exitStatus = commandCache.RunAndCache()
+		exitStatus, err = commandCache.RunAndCache()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}
 	exit(exitStatus)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -117,8 +117,12 @@ func TestSomething(t *testing.T) {
 		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
 		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
 	}
-	commandCache.RunAndCache()
-	commandCache.ReplayByCache()
+	if _, err := commandCache.RunAndCache(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := commandCache.ReplayByCache(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
@@ -146,7 +150,10 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 		}
 	}
 
-	exitStatus := commandCache.RunAndCache()
+	exitStatus, err := commandCache.RunAndCache()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if exitStatus != 7 {
 		t.Fatalf("unexpected exit status: %d", exitStatus)
 	}
@@ -163,5 +170,52 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 		if string(content) != expected {
 			t.Fatalf("%s = %q, want %q", path, string(content), expected)
 		}
+	}
+}
+
+func TestReplayByCacheRejectsInvalidStatus(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "cache-key"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "echo unreachable"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+	}
+
+	for path, value := range map[string]string{
+		commandCache.StatusFilepath: "not-a-status",
+		commandCache.OutFilepath:    "cached stdout",
+		commandCache.ErrFilepath:    "cached stderr",
+	} {
+		if err := ioutil.WriteFile(path, []byte(value), 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := commandCache.ReplayByCache(); err == nil {
+		t.Fatal("ReplayByCache() returned nil error for invalid status")
+	}
+}
+
+func TestRunAndCacheReturnsCommandStartError(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "cache-key"
+	commandCache := CommandCache{
+		Command:        []string{"cmd-cache-command-that-does-not-exist"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+	}
+
+	exitStatus, err := commandCache.RunAndCache()
+	if err == nil {
+		t.Fatal("RunAndCache() returned nil error for command start failure")
+	}
+	if exitStatus != 1 {
+		t.Fatalf("unexpected exit status: %d", exitStatus)
+	}
+	if _, err := os.Stat(commandCache.StatusFilepath); !os.IsNotExist(err) {
+		t.Fatalf("status file should not be cached for command start failure: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Return an error when a cached status file cannot be parsed as an exit status.
- Return command start failures from `RunAndCache` instead of caching them as successful exits.
- Add regression tests for invalid cached status files and command start failures.

## Validation
- `go test ./...`
- `./bin/test.sh`

Note: `./bin/test.sh` still prints the existing `go get -d` deprecation warning, but the script exits successfully.