### PR TITLE
Set explicit workflow permissions for golang-test and release

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
## Summary

Add a top-level `permissions: contents: read` block to `.github/workflows/golang-test.yml` and `.github/workflows/release.yml`, and elevate the `release.yml` `goreleaser` job to `contents: write` so GoReleaser can still update release assets.

The other workflows in this repository already declare explicit `permissions:` (`docker-release.yml`, `gitignore-in.yml`, `octocov.yml`, `spellcheck.yml`). This brings the two remaining workflows in line so the `GITHUB_TOKEN` scope each job receives is visible in the workflow file itself instead of inheriting the repository-level default.

## Why

Without an explicit `permissions:` block, each job uses the repository-default Actions permissions for `GITHUB_TOKEN`. Test-only workflows do not need write access; pinning them to `contents: read` makes the trust boundary explicit and stops them from gaining write capability if the repository default is later widened.

For `release.yml`, the `goreleaser` job is the only one that needs write — both for the `release` event (uploading assets) and to keep the existing PR-trigger path safe (read-only). Setting workflow-level read and job-level write keeps the elevation localized.

## Test plan

- [x] `actionlint .github/workflows/golang-test.yml .github/workflows/release.yml`
- [ ] CI on this PR (`golang-test`, `octocov`, etc.) passes with the new explicit permissions.
- [ ] After merge, confirm the next release run still uploads GoReleaser artifacts under the elevated job-level `contents: write`.