### PR TITLE
Wrap cached status parse error with status file context

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 	}
 	exitStatus, err := strconv.Atoi(string(exitStatusText))
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("invalid cached exit status in %s (%q): %w", cc.StatusFilepath, string(exitStatusText), err)
 	}
 	io.Copy(os.Stdout, outFile)
 	io.Copy(os.Stderr, errFile)

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	docopt "github.com/docopt/docopt-go"
@@ -193,8 +194,16 @@ func TestReplayByCacheRejectsInvalidStatus(t *testing.T) {
 		}
 	}
 
-	if _, err := commandCache.ReplayByCache(); err == nil {
+	_, err := commandCache.ReplayByCache()
+	if err == nil {
 		t.Fatal("ReplayByCache() returned nil error for invalid status")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, commandCache.StatusFilepath) {
+		t.Errorf("error message %q does not contain status filepath %q", msg, commandCache.StatusFilepath)
+	}
+	if !strings.Contains(msg, "not-a-status") {
+		t.Errorf("error message %q does not contain invalid status content", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Surface the status file path and the invalid content when `strconv.Atoi`
fails on a corrupted exit-status cache file in `CommandCache.ReplayByCache`.

Behavior is unchanged: the same error path is returned. The change wraps the
original `strconv.Atoi` error with `fmt.Errorf("invalid cached exit status in %s (%q): %w", ...)`,
so callers can see which cache file is corrupted and what content was rejected,
instead of only the bare `strconv.Atoi: parsing ...` message.

This protects the entrance to the cache replay path: when a cache directory
contains a partially-written or hand-edited status file, the user can read
the path from the error and remove or repair the offending entry without
guessing.

## Test plan

- [x] `go vet ./...`
- [x] `go mod tidy`
- [x] `go test -v -cover -race -covermode=atomic ./...` (all tests pass, coverage 83.3%)
- [x] `shellcheck bin/*.sh`

`TestReplayByCacheRejectsInvalidStatus` is extended to assert that the
returned error message contains both the status filepath and the invalid
status content (`not-a-status`).