### PR TITLE
Release file descriptors after each hash input

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,13 +49,7 @@ func (cc CommandContext) WriteToHash(h hash.Hash) {
 		io.WriteString(h, text)
 	}
 	for _, filename := range cc.Filenames {
-		io.WriteString(h, filename)
-		f, err := os.Open(filename)
-		if err != nil {
-			log.Fatal(err)
-		}
-		io.Copy(h, f)
-		defer f.Close()
+		writeFileToHash(h, filename)
 	}
 	for _, envname := range cc.EnvironmentVariableNames {
 		io.WriteString(h, envname)
@@ -63,6 +57,16 @@ func (cc CommandContext) WriteToHash(h hash.Hash) {
 			io.WriteString(h, value)
 		}
 	}
+}
+
+func writeFileToHash(h hash.Hash, filename string) {
+	io.WriteString(h, filename)
+	f, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	io.Copy(h, f)
 }
 
 type CommandCache struct {


### PR DESCRIPTION
## Background

`CommandContext.WriteToHash` opened each input file passed via `--file` and stacked `defer f.Close()` at the function scope. When multiple `--file` arguments were provided, every file descriptor stayed open until `WriteToHash` returned, so the number of simultaneously open fds grew linearly with the number of inputs.

## Change

Extract a `writeFileToHash` helper so the open / `io.Copy` / close sequence completes inside one iteration. The number of simultaneously open files is now bounded by 1 regardless of how many `--file` inputs are passed. The observable behaviour (hash contents, `log.Fatal` failure handling) is unchanged.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...` (existing 7 cases green)
- `gofmt -d main.go` reports no diff

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt` reports no diff