### PR TITLE
Check io.Copy errors when hashing inputs and replaying caches

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,9 @@ func writeFileToHash(h hash.Hash, filename string) {
 		log.Fatal(err)
 	}
 	defer f.Close()
-	io.Copy(h, f)
+	if _, err := io.Copy(h, f); err != nil {
+		log.Fatal(err)
+	}
 }
 
 type CommandCache struct {
@@ -100,8 +102,12 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid cached exit status in %s (%q): %w", cc.StatusFilepath, string(exitStatusText), err)
 	}
-	io.Copy(os.Stdout, outFile)
-	io.Copy(os.Stderr, errFile)
+	if _, err := io.Copy(os.Stdout, outFile); err != nil {
+		return 0, err
+	}
+	if _, err := io.Copy(os.Stderr, errFile); err != nil {
+		return 0, err
+	}
 	return exitStatus, nil
 }
 


### PR DESCRIPTION
## Summary

- `WriteToHash` ignored the `io.Copy(h, f)` return value when reading a
  depending file into the cache key. A read error (truncated source,
  closed descriptor) would silently produce an incomplete hash and a
  wrong cache key for the dependent command.
- `ReplayByCache` ignored `io.Copy` when replaying cached stdout / stderr,
  so a write or read error mid-replay would surface as a successful
  cache hit and the partial output would be treated as authoritative.

This change surfaces the errors at both sites:

- In `WriteToHash`, fail fast with `log.Fatal` to match the existing
  treatment of `os.Open` failures on the same input file.
- In `ReplayByCache`, return the error so `main` falls back to
  `RunAndCache` instead of finalising a partial cache replay.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `gofmt -d main.go`