### PR TITLE
Bump go directive to 1.24 and pin toolchain to 1.26 to drop stdlib vulns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/kitsuyui/cmd_cache
 
-go 1.19
+go 1.24.0
+
+toolchain go1.26.0
 
 require github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815


### PR DESCRIPTION
## Summary

`govulncheck ./...` against the Go 1.23.4 toolchain reports two stdlib
vulnerabilities reachable from this binary:

- [GO-2025-3956](https://pkg.go.dev/vuln/GO-2025-3956) — `os/exec.LookPath` returns unexpected paths. Fixed in `os/exec@go1.23.12`.
- [GO-2025-3750](https://pkg.go.dev/vuln/GO-2025-3750) — inconsistent `O_CREATE|O_EXCL` handling on Unix vs Windows in `os` / `syscall`. Fixed in `syscall@go1.23.10`.

The CI workflow (`.github/workflows/golang-test.yml`) already runs on Go
1.26.x with `check-latest: true`, so released artifacts are not affected
in practice, but the `go 1.19` directive without a `toolchain` override
caused tools that respect `go.mod` (including the
`kitsuyui/audit-toolchain` image, which pins Go 1.23.4) to fall back to
the older stdlib and continue flagging this module.

This PR bumps the `go` directive to `1.24.0` and adds
`toolchain go1.26.0`. With `GOTOOLCHAIN=auto`, audit tooling fetches a
recent stdlib that contains both fixes. The shape matches
`kitsuyui/myip`'s `go.mod`.

After this change, `GOTOOLCHAIN=go1.23.4+auto govulncheck ./...` reports
**0 vulnerabilities affecting code** for this module.

## Test plan

- [x] `go vet ./...`
- [x] `go test -v -cover -race -covermode=atomic ./...` (PASS, coverage 80.9%)
- [x] `GOTOOLCHAIN=go1.23.4+auto govulncheck ./...` → 0 affecting-code vulns