### PR TITLE
refactor: replace deprecated io/ioutil with io and os equivalents

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -94,7 +93,7 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 		return 0, err
 	}
 	defer statusFile.Close()
-	exitStatusText, err := ioutil.ReadAll(statusFile)
+	exitStatusText, err := io.ReadAll(statusFile)
 	if err != nil {
 		return 0, err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -146,7 +145,7 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 		commandCache.OutFilepath:    "previous stdout",
 		commandCache.ErrFilepath:    "previous stderr",
 	} {
-		if err := ioutil.WriteFile(path, []byte(value), 0666); err != nil {
+		if err := os.WriteFile(path, []byte(value), 0666); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -164,7 +163,7 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 		commandCache.OutFilepath:    "x",
 		commandCache.ErrFilepath:    "y",
 	} {
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -189,7 +188,7 @@ func TestReplayByCacheRejectsInvalidStatus(t *testing.T) {
 		commandCache.OutFilepath:    "cached stdout",
 		commandCache.ErrFilepath:    "cached stderr",
 	} {
-		if err := ioutil.WriteFile(path, []byte(value), 0666); err != nil {
+		if err := os.WriteFile(path, []byte(value), 0666); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
## Summary

- `io/ioutil` has been deprecated since Go 1.16 (SA1019 in staticcheck)
- Replace all three uses with their current equivalents:
  - `ioutil.ReadAll` → `io.ReadAll` (`main.go`)
  - `ioutil.ReadFile` → `os.ReadFile` (`main_test.go`)
  - `ioutil.WriteFile` → `os.WriteFile` (`main_test.go`)
- Both `io` and `os` were already imported; no new dependencies

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] No remaining `ioutil` references