### PR TITLE
Add concurrency to CI workflows

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -10,6 +10,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   push_to_registry:
     permissions:

--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   checks: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   octocov:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   goreleaser:
     permissions:


### PR DESCRIPTION
## Summary
- Add top-level concurrency groups to Docker release, Go test, coverage, and release workflows.
- Cancel in-progress runs for the same workflow and ref so stale branch/PR checks do not keep running.

## Verification
- `actionlint .github/workflows/*.yml`
- `shellcheck bin/*.sh`
- `go test ./...`
