### PR TITLE
fix: add null-byte separators to WriteToHash to prevent cache key collisions

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,23 +43,31 @@ type CommandContext struct {
 func (cc CommandContext) WriteToHash(h hash.Hash) {
 	for _, cmd := range cc.Command {
 		io.WriteString(h, cmd)
+		io.WriteString(h, "\x00")
 	}
+	io.WriteString(h, "\x01")
 	for _, text := range cc.Texts {
 		io.WriteString(h, text)
+		io.WriteString(h, "\x00")
 	}
+	io.WriteString(h, "\x01")
 	for _, filename := range cc.Filenames {
 		writeFileToHash(h, filename)
 	}
+	io.WriteString(h, "\x01")
 	for _, envname := range cc.EnvironmentVariableNames {
 		io.WriteString(h, envname)
+		io.WriteString(h, "\x00")
 		if value, ok := os.LookupEnv(envname); ok {
 			io.WriteString(h, value)
 		}
+		io.WriteString(h, "\x00")
 	}
 }
 
 func writeFileToHash(h hash.Hash, filename string) {
 	io.WriteString(h, filename)
+	io.WriteString(h, "\x00")
 	f, err := os.Open(filename)
 	if err != nil {
 		log.Fatal(err)
@@ -68,6 +76,7 @@ func writeFileToHash(h hash.Hash, filename string) {
 	if _, err := io.Copy(h, f); err != nil {
 		log.Fatal(err)
 	}
+	io.WriteString(h, "\x01")
 }
 
 type CommandCache struct {

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ func TestHashWhenEverythingIsEmpty(t *testing.T) {
 		EnvironmentVariableNames: []string{},
 		Filenames:                []string{},
 	})
-	if hashString != "da39a3ee5e6b4b0d3255bfef95601890afd80709" {
+	if hashString != "28d86c56b3bf26d236569b8dc8c3f91f32f47bc7" {
 		t.Error("Unexpected hash value:", hashString)
 	}
 }
@@ -72,7 +72,7 @@ func TestTextHash(t *testing.T) {
 		EnvironmentVariableNames: []string{},
 		Filenames:                []string{},
 	})
-	if hashString != "0a0a9f2a6772942557ab5355d76af442f8f65e01" {
+	if hashString != "cd5a4bda291ed743b9a4bf3e0e9109d7f83b0fe2" {
 		t.Error("Unexpected hash value:", hashString)
 	}
 }
@@ -85,7 +85,7 @@ func TestEnvHash(t *testing.T) {
 		EnvironmentVariableNames: []string{"LD_LIBRARY_PATH"},
 		Filenames:                []string{},
 	})
-	if hashString != "3d0fcf9d8dac962ba44dae6b205b541075451732" {
+	if hashString != "8475fc388c3fe8f6d3c5b52ab71f8476fff1c1b5" {
 		t.Error("Unexpected hash value:", hashString)
 	}
 }
@@ -103,8 +103,27 @@ func TestFileHash(t *testing.T) {
 		EnvironmentVariableNames: []string{},
 		Filenames:                []string{"build/testfile"},
 	})
-	if hashString != "8bfe40a6a2f5765f8e1d148bfb3d39d4fa0e709a" {
+	if hashString != "6d7e43ef5351becf7a79030cfa7325756176674b" {
 		t.Error("Unexpected hash value:", hashString)
+	}
+}
+
+func TestHashCollisionPrevented(t *testing.T) {
+	// "echo" command with "foo" text must differ from "echofoo" command alone.
+	hashCmdAndText := hashStringFromCommandContext(CommandContext{
+		Command:                  []string{"echo"},
+		Texts:                    []string{"foo"},
+		EnvironmentVariableNames: []string{},
+		Filenames:                []string{},
+	})
+	hashCmdOnly := hashStringFromCommandContext(CommandContext{
+		Command:                  []string{"echofoo"},
+		Texts:                    []string{},
+		EnvironmentVariableNames: []string{},
+		Filenames:                []string{},
+	})
+	if hashCmdAndText == hashCmdOnly {
+		t.Error("hash collision: {cmd:[echo], text:[foo]} must differ from {cmd:[echofoo]}")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `\x00` element separators after each string written by `CommandContext.WriteToHash`.
- Add `\x01` group separators between the Command, Texts, Filenames, and Env sections.
- Add separators after each filename and file body in `writeFileToHash`.
- Add `TestHashCollisionPrevented` to cover the collision case.

## Background

Without separators, semantically different argument groups can produce the same cache-key input. For example:

- `{cmd: ["echo"], text: ["foo"]}` writes `"echofoo"`.
- `{cmd: ["echofoo"]}` also writes `"echofoo"`.

The new delimiters make group and element boundaries explicit in the hash input.

## Impact on existing caches

This changes the cache key format, so existing cache entries will no longer be reused. That invalidates previous cache hits, but it prevents false hits for ambiguous inputs.

## Test plan

- [x] `TestHashCollisionPrevented` verifies that `{cmd:[echo], text:[foo]}` and `{cmd:[echofoo]}` produce different hashes.
- [x] Updated existing expected cache hashes for the new format.
- [x] `go test ./...`
- [x] `go vet`
