### PR TITLE
fix: do not cache non-zero exit status

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,6 +138,10 @@ func (cc CommandCache) RunAndCache() (int, error) {
 	} else if err != nil {
 		return 1, err
 	}
+	if exitStatus != 0 {
+		// Don't cache failures; the command should be retried on the next invocation.
+		return exitStatus, nil
+	}
 	statusFile, err := os.OpenFile(cc.StatusFilepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return exitStatus, err

--- a/main_test.go
+++ b/main_test.go
@@ -134,7 +134,7 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 	defer os.RemoveAll(cacheDirectory)
 
 	commandCache := CommandCache{
-		Command:        []string{"sh", "-c", "printf x; printf y >&2; exit 7"},
+		Command:        []string{"sh", "-c", "printf x; printf y >&2"},
 		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
 		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
 		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
@@ -154,12 +154,12 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if exitStatus != 7 {
+	if exitStatus != 0 {
 		t.Fatalf("unexpected exit status: %d", exitStatus)
 	}
 
 	for path, expected := range map[string]string{
-		commandCache.StatusFilepath: "7",
+		commandCache.StatusFilepath: "0",
 		commandCache.OutFilepath:    "x",
 		commandCache.ErrFilepath:    "y",
 	} {
@@ -170,6 +170,28 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 		if string(content) != expected {
 			t.Fatalf("%s = %q, want %q", path, string(content), expected)
 		}
+	}
+}
+
+func TestRunAndCacheDoesNotCacheFailures(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "cache-key"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "printf x; printf y >&2; exit 7"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+	}
+
+	exitStatus, err := commandCache.RunAndCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitStatus != 7 {
+		t.Fatalf("unexpected exit status: %d", exitStatus)
+	}
+	if _, err := os.Stat(commandCache.StatusFilepath); !os.IsNotExist(err) {
+		t.Fatal("status file must not be written for failed commands")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `RunAndCache()` no longer writes the status file when a command exits with a non-zero exit code
- On the next invocation, `ReplayByCache()` fails to find the status file and returns an error, causing the command to be re-executed
- Failures from transient errors (network outages, flaky external APIs) no longer persist indefinitely in the cache

## Test plan

- Updated `TestRunAndCacheTruncatesExistingCacheFiles` to use a successful command (exit 0) — the truncation behavior for out/err/status files is still covered
- Added `TestRunAndCacheDoesNotCacheFailures` — verifies that the status file is not written when the command exits with non-zero status