### PR TITLE
fix: prevent thundering herd with per-cache-key advisory lock

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,6 +133,39 @@ func (f *cacheTempFile) Rename() error {
 	return nil
 }
 
+// GetOrRun returns the cached result if available. On a cache miss it acquires
+// an exclusive advisory lock on a per-cache-key lock file, re-checks the cache
+// (another process may have populated it while we waited), and runs the command
+// only if the cache is still empty. This prevents multiple concurrent processes
+// from executing the same command (thundering herd / stampede).
+func (cc CommandCache) GetOrRun() (int, error) {
+	// Fast path: read from cache without acquiring a lock.
+	if exitStatus, err := cc.ReplayByCache(); err == nil {
+		return exitStatus, nil
+	}
+
+	lockPath := cc.StatusFilepath + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		// Lock file cannot be opened; fall back to running without a lock.
+		return cc.RunAndCache()
+	}
+	defer lockFile.Close()
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		// flock failed; fall back to running without a lock.
+		return cc.RunAndCache()
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+
+	// Double-check: another process may have written the cache while we waited.
+	if exitStatus, err := cc.ReplayByCache(); err == nil {
+		return exitStatus, nil
+	}
+
+	return cc.RunAndCache()
+}
+
 func (cc CommandCache) ReplayByCache() (int, error) {
 	outFile, err := os.Open(cc.OutFilepath)
 	if err != nil {
@@ -259,13 +292,9 @@ func main() {
 		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
 	}
 
-	var exitStatus int
-	exitStatus, err = commandCache.ReplayByCache()
+	exitStatus, err := commandCache.GetOrRun()
 	if err != nil {
-		exitStatus, err = commandCache.RunAndCache()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-		}
+		fmt.Fprintln(os.Stderr, err)
 	}
 	exit(exitStatus)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -215,6 +215,53 @@ func TestSomething(t *testing.T) {
 	}
 }
 
+func TestGetOrRunExecutesAndCachesOnMiss(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "cache-key"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "echo hello"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+	}
+
+	exitStatus, err := commandCache.GetOrRun()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitStatus != 0 {
+		t.Fatalf("unexpected exit status: %d", exitStatus)
+	}
+	if _, err := os.Stat(commandCache.StatusFilepath); err != nil {
+		t.Fatalf("status file must exist after GetOrRun: %v", err)
+	}
+}
+
+func TestGetOrRunReplaysCacheOnHit(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "cache-key"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "echo cached"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+	}
+
+	// First call: execute and cache.
+	if _, err := commandCache.GetOrRun(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call: cache hit via double-check path (lock acquired, cache found).
+	exitStatus, err := commandCache.GetOrRun()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitStatus != 0 {
+		t.Fatalf("unexpected exit status on cache hit: %d", exitStatus)
+	}
+}
+
 func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 	cacheDirectory := ".cmd_cache_test"
 	cacheKey := "cache-key"


### PR DESCRIPTION
## Summary

Multiple concurrent `cmd_cache` processes with the same cache key all
observed a cache miss and executed the expensive command simultaneously
(thundering herd / stampede). There was no advisory lock protecting the
check-then-act sequence.

## Changes

- Add `GetOrRun()` to `CommandCache` that wraps the cache-miss path with
  an exclusive `flock(2)` on a per-cache-key lock file.
- After acquiring the lock, `GetOrRun()` re-checks the cache before
  executing (double-checked locking pattern). If another process already
  wrote the result, it replays from cache instead of running the command.
- If the lock file cannot be opened or `flock` fails, execution falls back
  to the unguarded path so the tool remains functional on filesystems that
  do not support `flock`.
- Replace the `ReplayByCache` + `RunAndCache` call sequence in `main()`
  with a single `GetOrRun()` call.

## Test plan

- `TestGetOrRunExecutesAndCachesOnMiss`: verifies the command runs and
  writes the cache on the first call.
- `TestGetOrRunReplaysCacheOnHit`: verifies the second call reads from
  cache without re-executing the command.
- All existing tests pass with `-race`.