### PR TITLE
fix: redirect error output to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -227,7 +227,7 @@ var exit = os.Exit
 func main() {
 	opts, err := docopt.ParseDoc(COMMAND_USAGE)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		exit(1)
 	}
 	if showVersion, _ := opts.Bool("--version"); showVersion {
@@ -236,7 +236,7 @@ func main() {
 	}
 	cacheDirectory := opts["--cache-directory"].(string)
 	if err := os.MkdirAll(cacheDirectory, 0755); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		exit(1)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -81,6 +81,40 @@ func captureStdoutDuring(t *testing.T, fn func()) (string, any) {
 	return string(output), recovered
 }
 
+func captureStderrDuring(t *testing.T, fn func()) (string, any) {
+	t.Helper()
+
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = writer
+	log.SetOutput(writer)
+
+	var recovered any
+	func() {
+		defer func() {
+			recovered = recover()
+			os.Stderr = originalStderr
+			log.SetOutput(originalStderr)
+			if err := writer.Close(); err != nil {
+				t.Errorf("failed to close stderr writer: %v", err)
+			}
+		}()
+		fn()
+	}()
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output), recovered
+}
+
 func TestMainExitsWhenCacheDirectoryCannotBeCreated(t *testing.T) {
 	originalExit := exit
 	defer func() {
@@ -101,7 +135,7 @@ func TestMainExitsWhenCacheDirectoryCannotBeCreated(t *testing.T) {
 		panic(testExitCode(code))
 	}
 
-	output, recovered := captureStdoutDuring(t, main)
+	output, recovered := captureStderrDuring(t, main)
 	code, ok := recovered.(testExitCode)
 	if !ok {
 		t.Fatalf("main() recovered %v, want exit code panic", recovered)
@@ -109,11 +143,8 @@ func TestMainExitsWhenCacheDirectoryCannotBeCreated(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("unexpected exit code: %d", code)
 	}
-	if strings.Contains(output, "Usage:") {
-		t.Fatalf("docopt parse failed unexpectedly: %q", output)
-	}
 	if !strings.Contains(output, parentFile) {
-		t.Fatalf("output = %q, want mkdir error mentioning %q", output, parentFile)
+		t.Fatalf("stderr = %q, want mkdir error mentioning %q", output, parentFile)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two error messages in `main()` were printed to stdout using `fmt.Println(err)`:
- docopt argument parse errors
- cache directory creation errors (`os.MkdirAll`)

These are now printed to stderr using `fmt.Fprintln(os.Stderr, err)`, consistent
with the existing error output at the end of `main()` and `log.Fatal` calls elsewhere.

## Why

`cmd_cache` is designed to sit in a pipe: `cmd_cache ... -- go build | process`.
Diagnostic messages written to stdout pollute the data stream, causing the downstream
process to receive error strings it doesn't expect. Separating diagnostics to stderr
ensures the pipe receiver sees only the wrapped command's output.

The `log.Fatal` calls (e.g. in `writeFileToHash`) and the final `fmt.Fprintln(os.Stderr, err)`
already used stderr; this change makes the two remaining sites consistent.

## Test plan

- `captureStderrDuring` helper added to `main_test.go` (mirrors `captureStdoutDuring`)
- `TestMainExitsWhenCacheDirectoryCannotBeCreated` updated to capture stderr and assert
  the error message appears there instead of stdout
- `go test -race ./...` passes
