### PR TITLE
Print version to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -264,7 +264,7 @@ func main() {
 		exit(1)
 	}
 	if showVersion, _ := opts.Bool("--version"); showVersion {
-		println(version)
+		fmt.Println(version)
 		return
 	}
 	cacheDirectory := opts["--cache-directory"].(string)

--- a/main_test.go
+++ b/main_test.go
@@ -47,6 +47,28 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestMainWritesVersionToStdout(t *testing.T) {
+	originalArgs := os.Args
+	defer func() {
+		os.Args = originalArgs
+	}()
+	originalVersion := version
+	defer func() {
+		version = originalVersion
+	}()
+
+	version = "1.2.3-test"
+	os.Args = []string{"cmd_cache", "--version"}
+
+	output, recovered := captureStdoutDuring(t, main)
+	if recovered != nil {
+		t.Fatalf("main() recovered %v, want nil", recovered)
+	}
+	if output != "1.2.3-test\n" {
+		t.Fatalf("stdout = %q, want %q", output, "1.2.3-test\n")
+	}
+}
+
 type testExitCode int
 
 func captureStdoutDuring(t *testing.T, fn func()) (string, any) {


### PR DESCRIPTION
## Summary
- Print `--version` output with `fmt.Println` so it goes to stdout.
- Add a regression test that exercises `main()` and captures stdout for `--version`.

## Test plan
- `gofmt -w main.go main_test.go`
- `shellcheck bin/*.sh`
- `go vet ./...`
- `go mod tidy`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `git diff --check`
