### PR TITLE
fix: return error from writeFileToHash and WriteToHash instead of log.Fatal

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,7 +39,7 @@ type CommandContext struct {
 	Filenames                []string
 }
 
-func (cc CommandContext) WriteToHash(h hash.Hash) {
+func (cc CommandContext) WriteToHash(h hash.Hash) error {
 	for _, cmd := range cc.Command {
 		io.WriteString(h, cmd)
 		io.WriteString(h, "\x00")
@@ -52,7 +51,9 @@ func (cc CommandContext) WriteToHash(h hash.Hash) {
 	}
 	io.WriteString(h, "\x01")
 	for _, filename := range cc.Filenames {
-		writeFileToHash(h, filename)
+		if err := writeFileToHash(h, filename); err != nil {
+			return err
+		}
 	}
 	io.WriteString(h, "\x01")
 	for _, envname := range cc.EnvironmentVariableNames {
@@ -63,20 +64,22 @@ func (cc CommandContext) WriteToHash(h hash.Hash) {
 		}
 		io.WriteString(h, "\x00")
 	}
+	return nil
 }
 
-func writeFileToHash(h hash.Hash, filename string) {
+func writeFileToHash(h hash.Hash, filename string) error {
 	io.WriteString(h, filename)
 	io.WriteString(h, "\x00")
 	f, err := os.Open(filename)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer f.Close()
 	if _, err := io.Copy(h, f); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	io.WriteString(h, "\x01")
+	return nil
 }
 
 type CommandCache struct {
@@ -282,7 +285,10 @@ func main() {
 	}
 
 	h := sha1.New()
-	commandContext.WriteToHash(h)
+	if err := commandContext.WriteToHash(h); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exit(1)
+	}
 	cacheKey := hex.EncodeToString(h.Sum(nil))
 
 	commandCache := CommandCache{

--- a/main_test.go
+++ b/main_test.go
@@ -148,15 +148,17 @@ func TestMainExitsWhenCacheDirectoryCannotBeCreated(t *testing.T) {
 	}
 }
 
-func hashStringFromCommandContext(cc CommandContext) string {
+func hashStringFromCommandContext(t *testing.T, cc CommandContext) string {
+	t.Helper()
 	h := sha1.New()
-	cc.WriteToHash(h)
-	hashString := hex.EncodeToString(h.Sum(nil))
-	return hashString
+	if err := cc.WriteToHash(h); err != nil {
+		t.Fatalf("WriteToHash failed: %v", err)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func TestHashWhenEverythingIsEmpty(t *testing.T) {
-	hashString := hashStringFromCommandContext(CommandContext{
+	hashString := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{},
 		Texts:                    []string{},
 		EnvironmentVariableNames: []string{},
@@ -168,7 +170,7 @@ func TestHashWhenEverythingIsEmpty(t *testing.T) {
 }
 
 func TestTextHash(t *testing.T) {
-	hashString := hashStringFromCommandContext(CommandContext{
+	hashString := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{},
 		Texts:                    []string{"Hello, World!"},
 		EnvironmentVariableNames: []string{},
@@ -181,7 +183,7 @@ func TestTextHash(t *testing.T) {
 
 func TestEnvHash(t *testing.T) {
 	os.Setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib")
-	hashString := hashStringFromCommandContext(CommandContext{
+	hashString := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{},
 		Texts:                    []string{},
 		EnvironmentVariableNames: []string{"LD_LIBRARY_PATH"},
@@ -199,7 +201,7 @@ func TestFileHash(t *testing.T) {
 	}
 	outFile.Write([]byte("Hello, World!"))
 	defer outFile.Close()
-	hashString := hashStringFromCommandContext(CommandContext{
+	hashString := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{},
 		Texts:                    []string{},
 		EnvironmentVariableNames: []string{},
@@ -212,13 +214,13 @@ func TestFileHash(t *testing.T) {
 
 func TestHashCollisionPrevented(t *testing.T) {
 	// "echo" command with "foo" text must differ from "echofoo" command alone.
-	hashCmdAndText := hashStringFromCommandContext(CommandContext{
+	hashCmdAndText := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{"echo"},
 		Texts:                    []string{"foo"},
 		EnvironmentVariableNames: []string{},
 		Filenames:                []string{},
 	})
-	hashCmdOnly := hashStringFromCommandContext(CommandContext{
+	hashCmdOnly := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{"echofoo"},
 		Texts:                    []string{},
 		EnvironmentVariableNames: []string{},


### PR DESCRIPTION
## Summary

- `writeFileToHash` and `WriteToHash` called `log.Fatal` on error, which invokes `os.Exit(1)` and skips all deferred functions — including `defer f.Close()` — leaking file descriptors
- Both functions now return `error` instead; callers propagate the error up to `main()`, which prints to stderr and exits with code 1
- Removes the `log` import from `main.go`
- Updates `hashStringFromCommandContext` test helper signature to accept `*testing.T` and handle the returned error properly

## Changes

- `main.go`: `writeFileToHash` → `error` return, `WriteToHash` → `error` return, `main()` error handling
- `main_test.go`: `hashStringFromCommandContext(t, cc)` — passes `*testing.T`, uses `t.Fatalf` on error

## Test plan

- `go test -race ./...` passes
- `go vet ./...` passes
