### PR TITLE
docs: clarify misc/sketch.py is a historical prototype

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -1,0 +1,12 @@
+# misc
+
+This directory contains a historical Python prototype (`sketch.py`) written before the Go implementation existed.
+
+## sketch.py
+
+`sketch.py` is a proof-of-concept implementation of `cmd_cache` in Python using `asyncio` and `fcntl.flock`. It predates the Go implementation (`main.go`) and is **not actively maintained**.
+
+It includes features that were explored during the design phase but not carried forward into the Go version (e.g., `--algorithm` option, `--verbose` flag).
+
+**Status**: reference-only; not intended to be run or maintained alongside the Go implementation.
+If you are looking for the canonical implementation, see `main.go`.


### PR DESCRIPTION
## Summary

- Add `misc/README.md` to explain that `sketch.py` is a historical Python prototype that predates the Go implementation
- Clarifies the file is reference-only and not actively maintained alongside `main.go`

## Motivation

`misc/sketch.py` has lived in the repo since the initial commit with no indication of its role. The `misc/` directory name and `sketch` filename give no signal to new contributors about whether the Python implementation is:
- an alternative maintained in parallel with Go
- a design document / prototype to be removed
- a source of features to be ported to Go

The README makes the intent explicit without removing historical context.

## Changes

- `misc/README.md` (new): describes the directory purpose and the status of `sketch.py`

## Verification

- `go vet ./...` — no issues
- `go test -race ./...` — all tests pass
- No Go source files changed; documentation-only addition