### PR TITLE
fix: restore global state after tests and use isolated temp dirs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -14,15 +14,18 @@ import (
 )
 
 func TestMain(t *testing.T) {
+	originalExit := exit
+	defer func() { exit = originalExit }()
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
 	exit = func(i int) {
 		if i != 0 {
 			t.Error("exit code must be 0")
 		}
 	}
-	if err := os.RemoveAll(".cmd_cache"); err != nil {
-		panic(err)
-	}
-	os.Args = []string{"cmd_cache", "--text", "something", "--", "ls", "-ahl"}
+	cacheDir := t.TempDir()
+	os.Args = []string{"cmd_cache", "--cache-directory=" + cacheDir, "--text", "something", "--", "ls", "-ahl"}
 	// without cache
 	main()
 	// with cache
@@ -204,7 +207,7 @@ func TestTextHash(t *testing.T) {
 }
 
 func TestEnvHash(t *testing.T) {
-	os.Setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib")
+	t.Setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib")
 	hashString := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{},
 		Texts:                    []string{},
@@ -254,7 +257,7 @@ func TestHashCollisionPrevented(t *testing.T) {
 }
 
 func TestSomething(t *testing.T) {
-	cacheDirectory := ".cmd_cache"
+	cacheDirectory := t.TempDir()
 	cacheKey := "cache-key"
 	commandCache := CommandCache{
 		Command:        []string{"sh", "-c", "echo 1"},


### PR DESCRIPTION
## Summary

Three tests were leaking global state between runs, causing potential
ordering-dependent failures:

- `TestMain` replaced the package-level `exit` variable and `os.Args`
  without restoring them, and used `os.RemoveAll(".cmd_cache")` on a
  hardcoded shared directory.
- `TestEnvHash` called `os.Setenv` without cleanup, leaking
  `LD_LIBRARY_PATH` to subsequent tests.
- `TestSomething` used the same hardcoded `.cmd_cache` path, conflicting
  with `TestMain`.

## Why

Tests that mutate global state without cleanup are fragile: they can
pass or fail depending on execution order, and they leave side-effects
that are hard to diagnose. The same save/restore pattern is already
established in `TestMainExitsWhenCacheDirectoryCannotBeCreated`; this
change applies it consistently across the test file.

## Changes

- `TestMain`: save and defer-restore `exit` and `os.Args`; replace the
  hardcoded `.cmd_cache` removal with `t.TempDir()` passed via
  `--cache-directory`.
- `TestEnvHash`: replace `os.Setenv` with `t.Setenv`, which
  automatically reverts the variable when the test ends.
- `TestSomething`: replace the hardcoded `.cmd_cache` string with
  `t.TempDir()` for full test isolation.

## Test plan

- [ ] `go test -race ./...` passes
- [ ] Tests pass in both forward and reverse order (e.g., with `-shuffle=on`)
