### PR TITLE
fix: distinguish env var absent from empty in cache key hash

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func (cc CommandContext) WriteToHash(h hash.Hash) error {
 		io.WriteString(h, envname)
 		io.WriteString(h, "\x00")
 		if value, ok := os.LookupEnv(envname); ok {
+			io.WriteString(h, "\x02") // present marker: distinguishes set-to-empty from not-set
 			io.WriteString(h, value)
 		}
 		io.WriteString(h, "\x00")

--- a/main_test.go
+++ b/main_test.go
@@ -214,8 +214,32 @@ func TestEnvHash(t *testing.T) {
 		EnvironmentVariableNames: []string{"LD_LIBRARY_PATH"},
 		Filenames:                []string{},
 	})
-	if hashString != "8475fc388c3fe8f6d3c5b52ab71f8476fff1c1b5" {
+	if hashString != "b2c91fc952edc927a20d1802dcd650c79b0faa4b" {
 		t.Error("Unexpected hash value:", hashString)
+	}
+}
+
+func TestEnvHashAbsentVsEmptyCollisionPrevented(t *testing.T) {
+	// env var set to empty string must produce a different hash than env var not set
+	const testKey = "CMD_CACHE_TEST_ABSENT_EMPTY"
+	_ = os.Unsetenv(testKey)
+	hashNotSet := hashStringFromCommandContext(t, CommandContext{
+		Command:                  []string{},
+		Texts:                    []string{},
+		EnvironmentVariableNames: []string{testKey},
+		Filenames:                []string{},
+	})
+
+	t.Setenv(testKey, "")
+	hashSetToEmpty := hashStringFromCommandContext(t, CommandContext{
+		Command:                  []string{},
+		Texts:                    []string{},
+		EnvironmentVariableNames: []string{testKey},
+		Filenames:                []string{},
+	})
+
+	if hashNotSet == hashSetToEmpty {
+		t.Error("hash collision: env var set to empty must differ from env var not set")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -14,15 +14,18 @@ import (
 )
 
 func TestMain(t *testing.T) {
+	originalExit := exit
+	defer func() { exit = originalExit }()
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
 	exit = func(i int) {
 		if i != 0 {
 			t.Error("exit code must be 0")
 		}
 	}
-	if err := os.RemoveAll(".cmd_cache"); err != nil {
-		panic(err)
-	}
-	os.Args = []string{"cmd_cache", "--text", "something", "--", "ls", "-ahl"}
+	cacheDir := t.TempDir()
+	os.Args = []string{"cmd_cache", "--cache-directory=" + cacheDir, "--text", "something", "--", "ls", "-ahl"}
 	// without cache
 	main()
 	// with cache
@@ -204,7 +207,7 @@ func TestTextHash(t *testing.T) {
 }
 
 func TestEnvHash(t *testing.T) {
-	os.Setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib")
+	t.Setenv("LD_LIBRARY_PATH", "/usr/local/lib:/usr/lib")
 	hashString := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{},
 		Texts:                    []string{},
@@ -254,7 +257,7 @@ func TestHashCollisionPrevented(t *testing.T) {
 }
 
 func TestSomething(t *testing.T) {
-	cacheDirectory := ".cmd_cache"
+	cacheDirectory := t.TempDir()
 	cacheKey := "cache-key"
 	commandCache := CommandCache{
 		Command:        []string{"sh", "-c", "echo 1"},


### PR DESCRIPTION
## Summary

Add a `\x02` present-marker to the env var hash input so that a variable set to an empty string produces a different hash than a variable that is not set.

## Why

`WriteToHash` encoded both "env var not set" (`ok=false`) and "env var set to empty string" (`ok=true, value=""`) as `name\x00\x00`, making them hash-identical. Commands that branch on variable existence (e.g. bash `[[ -v VAR ]]` or `${VAR+x}` patterns) would get false cache hits: a cache entry built with `FOO=` set would be replayed when `FOO` was unset.

The fix writes a `\x02` byte before the value when `os.LookupEnv` returns `ok=true`, giving three distinct patterns:
- not set: `name\x00\x00`
- set to empty: `name\x00\x02\x00`
- set to value: `name\x00\x02value\x00`

Existing caches are invalidated by this change (intentional — the previous key was incorrect).

## Test plan

- [x] `go test -race ./...` passes
- [x] `TestEnvHashAbsentVsEmptyCollisionPrevented` asserts the two states produce different hashes
- [x] Updated expected hash in `TestEnvHash` to reflect the new encoding
