### PR TITLE
fix: normalize cache dependency input order

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Cache key can be generated with these way:
 - Environment variable (name and value)
 - Text
 
+Repeated `--file`, `--env`, and `--text` inputs are treated as dependency
+sets, so their order does not affect the cache key.
+
 ## Usage
 
 ### Example

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"syscall"
 
@@ -45,18 +46,18 @@ func (cc CommandContext) WriteToHash(h hash.Hash) error {
 		io.WriteString(h, "\x00")
 	}
 	io.WriteString(h, "\x01")
-	for _, text := range cc.Texts {
+	for _, text := range sortedStrings(cc.Texts) {
 		io.WriteString(h, text)
 		io.WriteString(h, "\x00")
 	}
 	io.WriteString(h, "\x01")
-	for _, filename := range cc.Filenames {
+	for _, filename := range sortedStrings(cc.Filenames) {
 		if err := writeFileToHash(h, filename); err != nil {
 			return err
 		}
 	}
 	io.WriteString(h, "\x01")
-	for _, envname := range cc.EnvironmentVariableNames {
+	for _, envname := range sortedStrings(cc.EnvironmentVariableNames) {
 		io.WriteString(h, envname)
 		io.WriteString(h, "\x00")
 		if value, ok := os.LookupEnv(envname); ok {
@@ -66,6 +67,12 @@ func (cc CommandContext) WriteToHash(h hash.Hash) error {
 		io.WriteString(h, "\x00")
 	}
 	return nil
+}
+
+func sortedStrings(values []string) []string {
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	return sorted
 }
 
 func writeFileToHash(h hash.Hash, filename string) error {

--- a/main_test.go
+++ b/main_test.go
@@ -243,6 +243,59 @@ func TestEnvHashAbsentVsEmptyCollisionPrevented(t *testing.T) {
 	}
 }
 
+func TestDependencyInputOrderDoesNotAffectHash(t *testing.T) {
+	const envA = "CMD_CACHE_TEST_ORDER_A"
+	const envB = "CMD_CACHE_TEST_ORDER_B"
+	t.Setenv(envA, "a")
+	t.Setenv(envB, "b")
+
+	tmpDir := t.TempDir()
+	fileA := filepath.Join(tmpDir, "a.txt")
+	fileB := filepath.Join(tmpDir, "b.txt")
+	if err := os.WriteFile(fileA, []byte("file a"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileB, []byte("file b"), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	first := hashStringFromCommandContext(t, CommandContext{
+		Command:                  []string{"sh", "-c", "echo order-sensitive-command"},
+		Texts:                    []string{"beta", "alpha"},
+		EnvironmentVariableNames: []string{envB, envA},
+		Filenames:                []string{fileB, fileA},
+	})
+	second := hashStringFromCommandContext(t, CommandContext{
+		Command:                  []string{"sh", "-c", "echo order-sensitive-command"},
+		Texts:                    []string{"alpha", "beta"},
+		EnvironmentVariableNames: []string{envA, envB},
+		Filenames:                []string{fileA, fileB},
+	})
+
+	if first != second {
+		t.Fatalf("dependency input order changed hash: %s != %s", first, second)
+	}
+}
+
+func TestCommandOrderStillAffectsHash(t *testing.T) {
+	first := hashStringFromCommandContext(t, CommandContext{
+		Command:                  []string{"echo", "hello"},
+		Texts:                    []string{},
+		EnvironmentVariableNames: []string{},
+		Filenames:                []string{},
+	})
+	second := hashStringFromCommandContext(t, CommandContext{
+		Command:                  []string{"hello", "echo"},
+		Texts:                    []string{},
+		EnvironmentVariableNames: []string{},
+		Filenames:                []string{},
+	})
+
+	if first == second {
+		t.Fatal("command order must remain part of the hash")
+	}
+}
+
 func TestFileHash(t *testing.T) {
 	outFile, err := os.OpenFile("build/testfile", os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Normalize repeated `--file`, `--env`, and `--text` inputs before hashing dependency inputs.
- Keep command argument ordering as part of the cache key.
- Document the order-insensitive dependency input behavior and add regression tests.

## Testing
- `go test ./...`
- `go vet ./...`
- `shellcheck bin/*.sh`
- `go mod tidy`
- `git diff --check`

