### PR TITLE
fix: restrict dependency file paths to working tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ When cache doesn't exist, run command and cache it.
 Cache key can be generated with these way:
 
 - Command
-- File content (path and content)
+- File content (relative path and content)
 - Environment variable (name and value)
 - Text
 
 Repeated `--file`, `--env`, and `--text` inputs are treated as dependency
 sets, so their order does not affect the cache key.
+
+`--file` values must be relative paths inside the current working directory.
+Absolute paths and paths that escape the current working directory are rejected.
 
 ## Usage
 
@@ -37,7 +40,7 @@ Usage:
  cmd_cache (--help | --version)
 
 Arguments:
- FILE      depending file. (e.g. prog.h)
+ FILE      depending file under the current working directory. (e.g. prog.h)
  ENV       depending environment variable. (e.g. LD_LIBRARY_PATH)
  TEXT      text affecting command.
  COMMAND   real command.

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/docopt/docopt-go"
@@ -22,7 +23,7 @@ Usage:
  cmd_cache (--help | --version)
 
 Arguments:
- FILE      depending file. (e.g. prog.h)
+ FILE      depending file under the current working directory. (e.g. prog.h)
  ENV       depending environment variable. (e.g. LD_LIBRARY_PATH)
  TEXT      text affecting command.
  COMMAND   real command.
@@ -76,6 +77,9 @@ func sortedStrings(values []string) []string {
 }
 
 func writeFileToHash(h hash.Hash, filename string) error {
+	if err := validateDependencyFilename(filename); err != nil {
+		return err
+	}
 	io.WriteString(h, filename)
 	io.WriteString(h, "\x00")
 	f, err := os.Open(filename)
@@ -87,6 +91,20 @@ func writeFileToHash(h hash.Hash, filename string) error {
 		return err
 	}
 	io.WriteString(h, "\x01")
+	return nil
+}
+
+func validateDependencyFilename(filename string) error {
+	if filename == "" {
+		return fmt.Errorf("dependency file path must not be empty")
+	}
+	clean := filepath.Clean(filename)
+	if filepath.IsAbs(clean) {
+		return fmt.Errorf("dependency file path %q must be relative to the current working directory", filename)
+	}
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("dependency file path %q must not escape the current working directory", filename)
+	}
 	return nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -250,8 +250,9 @@ func TestDependencyInputOrderDoesNotAffectHash(t *testing.T) {
 	t.Setenv(envB, "b")
 
 	tmpDir := t.TempDir()
-	fileA := filepath.Join(tmpDir, "a.txt")
-	fileB := filepath.Join(tmpDir, "b.txt")
+	t.Chdir(tmpDir)
+	fileA := "a.txt"
+	fileB := "b.txt"
 	if err := os.WriteFile(fileA, []byte("file a"), 0666); err != nil {
 		t.Fatal(err)
 	}
@@ -311,6 +312,29 @@ func TestFileHash(t *testing.T) {
 	})
 	if hashString != "6d7e43ef5351becf7a79030cfa7325756176674b" {
 		t.Error("Unexpected hash value:", hashString)
+	}
+}
+
+func TestFileHashRejectsParentDirectoryTraversal(t *testing.T) {
+	h := sha1.New()
+	err := writeFileToHash(h, "../outside.txt")
+	if err == nil {
+		t.Fatal("writeFileToHash accepted a dependency path outside the current working directory")
+	}
+	if !strings.Contains(err.Error(), "must not escape the current working directory") {
+		t.Fatalf("error = %q, want current working directory escape message", err)
+	}
+}
+
+func TestFileHashRejectsAbsolutePath(t *testing.T) {
+	h := sha1.New()
+	absolutePath := filepath.Join(t.TempDir(), "dependency.txt")
+	err := writeFileToHash(h, absolutePath)
+	if err == nil {
+		t.Fatal("writeFileToHash accepted an absolute dependency path")
+	}
+	if !strings.Contains(err.Error(), "must be relative to the current working directory") {
+		t.Fatalf("error = %q, want relative path message", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject `--file` dependency paths that are absolute or escape the current working directory before hashing/opening them
- document the relative dependency path contract in the CLI help and README
- add coverage for rejected parent traversal and absolute dependency paths

## Verification
- `go test ./...`
- `go vet ./...`
- `shellcheck bin/*.sh`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `git diff --check`
