### PR TITLE
fix: use ExitCode() instead of Sys() type assertion for exit status

### DIFF
--- a/main.go
+++ b/main.go
@@ -250,8 +250,9 @@ func (cc CommandCache) RunAndCache() (int, error) {
 	err = cmd.Run()
 	var exitStatus int
 	if err2, ok := err.(*exec.ExitError); ok {
-		if s, ok := err2.Sys().(syscall.WaitStatus); ok {
-			exitStatus = s.ExitStatus()
+		exitStatus = err2.ExitCode()
+		if exitStatus == -1 {
+			exitStatus = 1 // signal-terminated; no numeric exit code available
 		}
 	} else if err != nil {
 		return 1, err


### PR DESCRIPTION
## Summary

Replace the `err2.Sys().(syscall.WaitStatus)` inner type assertion in `RunAndCache` with `err2.ExitCode()`, the canonical Go API available since 1.12.

## Why

When `cmd.Run()` returns `*exec.ExitError` (outer assertion succeeds) but `err2.Sys().(syscall.WaitStatus)` returns `ok=false` (inner assertion fails), `exitStatus` stays 0. The `else if err != nil` branch is unreachable because the outer branch already matched, so no error is returned either. The result: a genuinely failed command is cached with exit status 0 and replayed as a success on subsequent calls.

`ExitCode()` returns the exit code directly for normal exits, and -1 for signal-terminated processes. The -1 case is mapped to 1 to preserve non-zero failure semantics.

On Linux/macOS `Sys()` always returns `syscall.WaitStatus`, so this was a latent correctness issue rather than a frequently triggered bug. The new path is portable and removes the dependency on platform-specific type assertions.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all existing tests)
- [x] `staticcheck ./...` — 0 issues
