### PR TITLE
fix: preserve stdout/stderr interleaving order on cache replay

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/sha1"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -12,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/docopt/docopt-go"
@@ -113,6 +115,32 @@ type CommandCache struct {
 	StatusFilepath string
 	OutFilepath    string
 	ErrFilepath    string
+	// MuxFilepath stores an interleaved stdout/stderr stream so ReplayByCache can
+	// reproduce the original write order instead of replaying all stdout then all
+	// stderr. Empty string disables mux writing and falls back to sequential replay.
+	MuxFilepath string
+}
+
+// muxWriter writes framed chunks to a shared multiplexed file.
+// Each Write call emits [stream_id (1 byte)][length (4 bytes big-endian)][data].
+// The mutex is shared between the stdout and stderr writers so that frames from
+// concurrent goroutines are never interleaved mid-frame.
+type muxWriter struct {
+	mu     *sync.Mutex
+	w      io.Writer
+	stream byte // 1 = stdout, 2 = stderr
+}
+
+func (m *muxWriter) Write(p []byte) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var header [5]byte
+	header[0] = m.stream
+	binary.BigEndian.PutUint32(header[1:], uint32(len(p)))
+	if _, err := m.w.Write(header[:]); err != nil {
+		return 0, err
+	}
+	return m.w.Write(p)
 }
 
 type cacheTempFile struct {
@@ -219,6 +247,15 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid cached exit status in %s (%q): %w", cc.StatusFilepath, string(exitStatusText), err)
 	}
+	// Prefer the mux file when available: it preserves the original stdout/stderr
+	// interleaving order captured during RunAndCache. Old caches without a mux
+	// file fall back to the sequential (all-stdout-then-all-stderr) path below.
+	if cc.MuxFilepath != "" {
+		if muxFile, err := os.Open(cc.MuxFilepath); err == nil {
+			defer muxFile.Close()
+			return exitStatus, replayMux(muxFile)
+		}
+	}
 	if _, err := io.Copy(os.Stdout, outFile); err != nil {
 		return 0, err
 	}
@@ -226,6 +263,36 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 		return 0, err
 	}
 	return exitStatus, nil
+}
+
+// replayMux reads a mux stream written by muxWriter and dispatches each frame
+// to os.Stdout (stream_id=1) or os.Stderr (stream_id=2).
+func replayMux(r io.Reader) error {
+	var header [5]byte
+	for {
+		if _, err := io.ReadFull(r, header[:]); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("reading mux header: %w", err)
+		}
+		stream := header[0]
+		length := binary.BigEndian.Uint32(header[1:])
+		data := make([]byte, length)
+		if _, err := io.ReadFull(r, data); err != nil {
+			return fmt.Errorf("reading mux data: %w", err)
+		}
+		switch stream {
+		case 1:
+			if _, err := os.Stdout.Write(data); err != nil {
+				return err
+			}
+		case 2:
+			if _, err := os.Stderr.Write(data); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func (cc CommandCache) RunAndCache() (int, error) {
@@ -239,8 +306,25 @@ func (cc CommandCache) RunAndCache() (int, error) {
 		return 1, err
 	}
 	defer errFile.Remove()
-	outWriter := io.MultiWriter(outFile.file, os.Stdout)
-	errWriter := io.MultiWriter(errFile.file, os.Stderr)
+
+	// Create a mux file to record stdout/stderr in original write order so that
+	// ReplayByCache can reproduce the interleaving instead of replaying all
+	// stdout before all stderr.
+	var muxMu sync.Mutex
+	var muxFile *cacheTempFile
+	outWriters := []io.Writer{outFile.file, os.Stdout}
+	errWriters := []io.Writer{errFile.file, os.Stderr}
+	if cc.MuxFilepath != "" {
+		muxFile, err = newCacheTempFile(cc.MuxFilepath)
+		if err != nil {
+			return 1, err
+		}
+		defer muxFile.Remove()
+		outWriters = append(outWriters, &muxWriter{mu: &muxMu, w: muxFile.file, stream: 1})
+		errWriters = append(errWriters, &muxWriter{mu: &muxMu, w: muxFile.file, stream: 2})
+	}
+	outWriter := io.MultiWriter(outWriters...)
+	errWriter := io.MultiWriter(errWriters...)
 
 	commands := cc.Command
 	cmd := exec.Command(commands[0], commands[1:]...)
@@ -280,6 +364,11 @@ func (cc CommandCache) RunAndCache() (int, error) {
 	}
 	if err := statusFile.Rename(); err != nil {
 		return exitStatus, err
+	}
+	if muxFile != nil {
+		if err := muxFile.Rename(); err != nil {
+			return exitStatus, err
+		}
 	}
 	return exitStatus, nil
 }
@@ -323,6 +412,7 @@ func main() {
 		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
 		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
 		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+		MuxFilepath:    filepath.Join(cacheDirectory, cacheKey+"_mux"),
 	}
 
 	exitStatus, err := commandCache.GetOrRun()

--- a/main_test.go
+++ b/main_test.go
@@ -549,6 +549,73 @@ func TestRunAndCacheReturnsCommandStartError(t *testing.T) {
 	assertNoCacheTempFiles(t, cacheDirectory)
 }
 
+func TestRunAndCacheCreatesMuxFileAndReplayPreservesStreams(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "mux-test"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "printf out; printf err >&2"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+		MuxFilepath:    filepath.Join(cacheDirectory, cacheKey+"_mux"),
+	}
+
+	if _, err := commandCache.RunAndCache(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(commandCache.MuxFilepath); err != nil {
+		t.Fatal("mux file must exist after RunAndCache:", err)
+	}
+	assertNoCacheTempFiles(t, cacheDirectory)
+
+	// ReplayByCache must use the mux file and deliver correct stdout/stderr content.
+	stdout, _ := captureStdoutDuring(t, func() {
+		stderr, _ := captureStderrDuring(t, func() {
+			if _, err := commandCache.ReplayByCache(); err != nil {
+				t.Errorf("ReplayByCache failed: %v", err)
+			}
+		})
+		if stderr != "err" {
+			t.Errorf("stderr = %q, want %q", stderr, "err")
+		}
+	})
+	if stdout != "out" {
+		t.Errorf("stdout = %q, want %q", stdout, "out")
+	}
+}
+
+func TestReplayByCacheFallsBackToSequentialWithoutMuxFile(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "no-mux-test"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "printf old-out; printf old-err >&2"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+		MuxFilepath:    filepath.Join(cacheDirectory, cacheKey+"_mux"),
+	}
+
+	// Write old-format cache files (no mux file).
+	for path, content := range map[string]string{
+		commandCache.StatusFilepath: "0",
+		commandCache.OutFilepath:    "old-out",
+		commandCache.ErrFilepath:    "old-err",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// ReplayByCache must fall back to stdout-then-stderr without error.
+	exitStatus, err := commandCache.ReplayByCache()
+	if err != nil {
+		t.Fatal("ReplayByCache failed on old-format cache:", err)
+	}
+	if exitStatus != 0 {
+		t.Fatalf("unexpected exit status: %d", exitStatus)
+	}
+}
+
 func assertNoCacheTempFiles(t *testing.T, cacheDirectory string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Cache hit replay replayed all stdout before all stderr, while cache miss
interleaved them in real time. Users who piped mixed output (e.g.
`cmd_cache -- build 2>&1 | grep ...`) would see different results between
first run and subsequent cached runs.

## Why

`ReplayByCache` used sequential `io.Copy` calls (stdout first, then stderr),
while `RunAndCache` streamed both concurrently to `MultiWriter`s. This made
the replay order of a cache hit structurally different from a fresh run.

## Changes

- Added `MuxFilepath` field to `CommandCache`. When set, `RunAndCache` writes
  a multiplexed stream file (`_mux`) alongside the existing `_out` and `_err`
  files. Each write is tagged with a 1-byte stream ID (1=stdout, 2=stderr)
  and a 4-byte big-endian length so the original interleaving is preserved.
- `ReplayByCache` opens the `_mux` file when present and dispatches frames to
  the correct stream in recorded order. Old cache entries without a `_mux`
  file continue to use the previous stdout-then-stderr sequential fallback.
- `main` sets `MuxFilepath` to `<cache_key>_mux`.

## Backward compatibility

Existing cache entries (no `_mux` file) replay unchanged. New entries gain a
`_mux` file; deleting it falls back silently to sequential replay.

## Test plan

- [x] `go test ./...` passes
- [x] `TestRunAndCacheCreatesMuxFileAndReplayPreservesStreams`: mux file created; stdout/stderr content correct on replay
- [x] `TestReplayByCacheFallsBackToSequentialWithoutMuxFile`: old-format caches replay without error