### PR TITLE
docs: clarify that child command inherits full process environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ sets, so their order does not affect the cache key.
 `--file` values must be relative paths inside the current working directory.
 Absolute paths and paths that escape the current working directory are rejected.
 
+## Environment variable inheritance
+
+The cache key only includes the environment variables listed with `--env`.
+However, the wrapped command inherits the **entire** process environment when
+it runs — not just the `--env` variables.
+
+This means variables like `PATH`, `HOME`, `LANG`, and `TZ` silently affect
+which binary is resolved and how the command behaves, even though they are
+not part of the cache key.
+
+If any unlisted environment variable affects the command's output, add it
+with `--env` to include it in the cache key:
+
+```sh
+cmd_cache --env PATH --env LANG -- my-command
+```
+
+Shared cache directories across machines or CI environments with different
+`PATH` or locale settings can produce stale replays from a cache hit.
+
 ## Usage
 
 ### Example

--- a/main.go
+++ b/main.go
@@ -244,6 +244,9 @@ func (cc CommandCache) RunAndCache() (int, error) {
 
 	commands := cc.Command
 	cmd := exec.Command(commands[0], commands[1:]...)
+	// Pass the full process environment so commands can resolve binaries via PATH
+	// and read user config via HOME. Only --env variables are in the cache key;
+	// callers must list any env var that affects output.
 	cmd.Env = os.Environ()
 	cmd.Stdout = outWriter
 	cmd.Stderr = errWriter


### PR DESCRIPTION
## Summary

Document the implicit behavior that `cmd_cache` passes the full process environment to the wrapped command, even though only `--env`-listed variables contribute to the cache key.

## Problem

The cache key model suggests only `--env` variables affect results. In practice, `PATH`, `HOME`, `LANG`, `TZ`, and other unlisted variables are silently inherited by the child process. This means:

- Two machines with different `PATH` settings can hit the same cache key but execute different binaries
- A shared cache directory across CI and local may produce stale replays

None of this is documented, making it an implicit contract users must discover empirically.

## Changes

- `README.md`: add an "Environment variable inheritance" section explaining the full-environment-pass behavior, with guidance on which variables to list via `--env`
- `main.go`: add a comment at `cmd.Env = os.Environ()` explaining why the full environment is passed and what callers are responsible for

## No behavior change

This PR is documentation-only. The execution model is unchanged. The structural fix (filtering child env to `--env` variables) and the design fix (adding `--strict-env` mode) were considered but deferred as they would be breaking changes requiring separate discussion.

## Verification

```sh
go build ./...
go test ./...
typos README.md main.go
```

All pass with no changes.
