### PR TITLE
Bound cache entries by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ sets, so their order does not affect the cache key.
 `--file` values must be relative paths inside the current working directory.
 Absolute paths and paths that escape the current working directory are rejected.
 
+By default, `cmd_cache` keeps the newest 1024 complete cache entries in the
+cache directory and prunes older entries after each run. Set
+`--max-cache-entries=0` to disable pruning.
+
 ## Environment variable inheritance
 
 The cache key only includes the environment variables listed with `--env`.
@@ -56,7 +60,7 @@ $ cmd_cache --file depedingfile.go --env GOPATH -- go build
 cmd_cache
 
 Usage:
- cmd_cache [--cache-directory=DIRECTORY] [(--file FILE | --env ENV | --text TEXT)...] -- [COMMAND...]
+ cmd_cache [--cache-directory=DIRECTORY] [--max-cache-entries=COUNT] [(--file FILE | --env ENV | --text TEXT)...] -- [COMMAND...]
  cmd_cache (--help | --version)
 
 Arguments:
@@ -69,6 +73,7 @@ Options:
  -h --help               						 Show this screen.
  -V --version            						 Show version.
  --cache-directory=DIRECTORY    Cache directory [default: .cmd_cache]
+ --max-cache-entries=COUNT      Maximum complete cache entries to keep; 0 disables pruning [default: 1024]
 ```
 
 # Build

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -15,13 +16,14 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/docopt/docopt-go"
 )
 
 const COMMAND_USAGE = `cmd_cache
 Usage:
- cmd_cache [--cache-directory=DIRECTORY] [(--file FILE | --env ENV | --text TEXT)...] -- [COMMAND...]
+ cmd_cache [--cache-directory=DIRECTORY] [--max-cache-entries=COUNT] [(--file FILE | --env ENV | --text TEXT)...] -- [COMMAND...]
  cmd_cache (--help | --version)
 
 Arguments:
@@ -34,6 +36,7 @@ Options:
  -h --help               						 Show this screen.
  -V --version            						 Show version.
  --cache-directory=DIRECTORY    Cache directory [default: .cmd_cache]
+ --max-cache-entries=COUNT      Maximum complete cache entries to keep; 0 disables pruning [default: 1024]
 `
 
 type CommandContext struct {
@@ -119,6 +122,16 @@ type CommandCache struct {
 	// reproduce the original write order instead of replaying all stdout then all
 	// stderr. Empty string disables mux writing and falls back to sequential replay.
 	MuxFilepath string
+}
+
+type cacheEntry struct {
+	Key            string
+	StatusFilepath string
+	OutFilepath    string
+	ErrFilepath    string
+	MuxFilepath    string
+	LockFilepath   string
+	ModTime        time.Time
 }
 
 // muxWriter writes framed chunks to a shared multiplexed file.
@@ -376,6 +389,114 @@ func (cc CommandCache) RunAndCache() (int, error) {
 	return exitStatus, nil
 }
 
+func parseMaxCacheEntries(value string) (int, error) {
+	maxCacheEntries, err := strconv.Atoi(value)
+	if err != nil || maxCacheEntries < 0 {
+		return 0, fmt.Errorf("--max-cache-entries must be a non-negative integer: %q", value)
+	}
+	return maxCacheEntries, nil
+}
+
+func isCacheKey(name string) bool {
+	if len(name) != sha1.Size*2 {
+		return false
+	}
+	for _, r := range name {
+		if !('0' <= r && r <= '9') && !('a' <= r && r <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func collectCompleteCacheEntries(cacheDirectory string) ([]cacheEntry, error) {
+	dirEntries, err := os.ReadDir(cacheDirectory)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]cacheEntry, 0, len(dirEntries))
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			continue
+		}
+		key := dirEntry.Name()
+		if !isCacheKey(key) ||
+			strings.HasPrefix(key, ".") ||
+			strings.HasSuffix(key, "_out") ||
+			strings.HasSuffix(key, "_err") ||
+			strings.HasSuffix(key, "_mux") ||
+			strings.HasSuffix(key, ".lock") {
+			continue
+		}
+
+		statusPath := filepath.Join(cacheDirectory, key)
+		outPath := filepath.Join(cacheDirectory, key+"_out")
+		errPath := filepath.Join(cacheDirectory, key+"_err")
+		statusInfo, err := dirEntry.Info()
+		if err != nil {
+			continue
+		}
+		outInfo, err := os.Stat(outPath)
+		if err != nil {
+			continue
+		}
+		errInfo, err := os.Stat(errPath)
+		if err != nil {
+			continue
+		}
+
+		modTime := statusInfo.ModTime()
+		for _, info := range []os.FileInfo{outInfo, errInfo} {
+			if info.ModTime().After(modTime) {
+				modTime = info.ModTime()
+			}
+		}
+
+		entries = append(entries, cacheEntry{
+			Key:            key,
+			StatusFilepath: statusPath,
+			OutFilepath:    outPath,
+			ErrFilepath:    errPath,
+			MuxFilepath:    filepath.Join(cacheDirectory, key+"_mux"),
+			LockFilepath:   statusPath + ".lock",
+			ModTime:        modTime,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].ModTime.Equal(entries[j].ModTime) {
+			return entries[i].Key < entries[j].Key
+		}
+		return entries[i].ModTime.Before(entries[j].ModTime)
+	})
+	return entries, nil
+}
+
+func pruneCacheEntries(cacheDirectory string, maxEntries int) error {
+	if maxEntries <= 0 {
+		return nil
+	}
+
+	entries, err := collectCompleteCacheEntries(cacheDirectory)
+	if err != nil {
+		return err
+	}
+	if len(entries) <= maxEntries {
+		return nil
+	}
+
+	var errs []error
+	for _, entry := range entries[:len(entries)-maxEntries] {
+		for _, path := range []string{entry.StatusFilepath, entry.OutFilepath, entry.ErrFilepath, entry.MuxFilepath, entry.LockFilepath} {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
 var version string
 var exit = os.Exit
 
@@ -390,6 +511,11 @@ func main() {
 		return
 	}
 	cacheDirectory := opts["--cache-directory"].(string)
+	maxCacheEntries, err := parseMaxCacheEntries(opts["--max-cache-entries"].(string))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exit(1)
+	}
 	if err := os.MkdirAll(cacheDirectory, 0755); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
@@ -421,6 +547,9 @@ func main() {
 	exitStatus, err := commandCache.GetOrRun()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+	}
+	if pruneErr := pruneCacheEntries(cacheDirectory, maxCacheEntries); pruneErr != nil {
+		fmt.Fprintln(os.Stderr, pruneErr)
 	}
 	exit(exitStatus)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	docopt "github.com/docopt/docopt-go"
 )
@@ -613,6 +614,226 @@ func TestReplayByCacheFallsBackToSequentialWithoutMuxFile(t *testing.T) {
 	}
 	if exitStatus != 0 {
 		t.Fatalf("unexpected exit status: %d", exitStatus)
+	}
+}
+
+func TestParseMaxCacheEntries(t *testing.T) {
+	for input, expected := range map[string]int{
+		"0":    0,
+		"1":    1,
+		"1024": 1024,
+	} {
+		actual, err := parseMaxCacheEntries(input)
+		if err != nil {
+			t.Fatalf("parseMaxCacheEntries(%q) returned error: %v", input, err)
+		}
+		if actual != expected {
+			t.Fatalf("parseMaxCacheEntries(%q) = %d, want %d", input, actual, expected)
+		}
+	}
+
+	for _, input := range []string{"", "-1", "abc"} {
+		if _, err := parseMaxCacheEntries(input); err == nil {
+			t.Fatalf("parseMaxCacheEntries(%q) returned nil error", input)
+		}
+	}
+}
+
+func TestIsCacheKey(t *testing.T) {
+	validKey := "0123456789abcdef0123456789abcdef01234567"
+	if !isCacheKey(validKey) {
+		t.Fatalf("isCacheKey(%q) = false, want true", validKey)
+	}
+
+	for _, input := range []string{
+		"short",
+		"0123456789abcdef0123456789abcdef0123456g",
+		"0123456789ABCDEF0123456789abcdef01234567",
+		"cache-key",
+	} {
+		if isCacheKey(input) {
+			t.Fatalf("isCacheKey(%q) = true, want false", input)
+		}
+	}
+}
+
+func TestMainRejectsInvalidMaxCacheEntries(t *testing.T) {
+	originalExit := exit
+	defer func() {
+		exit = originalExit
+	}()
+	originalArgs := os.Args
+	defer func() {
+		os.Args = originalArgs
+	}()
+
+	os.Args = []string{"cmd_cache", "--max-cache-entries=-1", "--", "sh", "-c", "echo should-not-run"}
+	exit = func(code int) {
+		panic(testExitCode(code))
+	}
+
+	output, recovered := captureStderrDuring(t, main)
+	code, ok := recovered.(testExitCode)
+	if !ok {
+		t.Fatalf("main() recovered %v, want exit code panic", recovered)
+	}
+	if code != 1 {
+		t.Fatalf("unexpected exit code: %d", code)
+	}
+	if !strings.Contains(output, "--max-cache-entries must be a non-negative integer") {
+		t.Fatalf("stderr = %q, want max-cache-entries validation error", output)
+	}
+}
+
+func TestPruneCacheEntriesRemovesOldestCompleteEntries(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	oldTime := time.Unix(100, 0)
+	middleTime := time.Unix(200, 0)
+	newTime := time.Unix(300, 0)
+	oldKey := "0000000000000000000000000000000000000001"
+	middleKey := "0000000000000000000000000000000000000002"
+	newKey := "0000000000000000000000000000000000000003"
+
+	writeCompleteCacheEntry(t, cacheDirectory, oldKey, oldTime)
+	writeCompleteCacheEntry(t, cacheDirectory, middleKey, middleTime)
+	writeCompleteCacheEntry(t, cacheDirectory, newKey, newTime)
+
+	if err := pruneCacheEntries(cacheDirectory, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	assertCacheEntryRemoved(t, cacheDirectory, oldKey)
+	assertCacheEntryExists(t, cacheDirectory, middleKey)
+	assertCacheEntryExists(t, cacheDirectory, newKey)
+
+	entries, err := collectCompleteCacheEntries(cacheDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("complete entries = %d, want 2", len(entries))
+	}
+}
+
+func TestPruneCacheEntriesIgnoresIncompleteEntries(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	oldCompleteKey := "0000000000000000000000000000000000000001"
+	newCompleteKey := "0000000000000000000000000000000000000002"
+	incompleteKey := "0000000000000000000000000000000000000003"
+	writeCompleteCacheEntry(t, cacheDirectory, oldCompleteKey, time.Unix(100, 0))
+	writeCompleteCacheEntry(t, cacheDirectory, newCompleteKey, time.Unix(300, 0))
+	writePartialCacheEntry(t, cacheDirectory, incompleteKey, time.Unix(1, 0))
+
+	if err := pruneCacheEntries(cacheDirectory, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	assertCacheEntryRemoved(t, cacheDirectory, oldCompleteKey)
+	assertCacheEntryExists(t, cacheDirectory, newCompleteKey)
+	assertPartialCacheEntryExists(t, cacheDirectory, incompleteKey)
+}
+
+func TestPruneCacheEntriesDisabledKeepsCompleteEntries(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	oldKey := "0000000000000000000000000000000000000001"
+	newKey := "0000000000000000000000000000000000000002"
+	writeCompleteCacheEntry(t, cacheDirectory, oldKey, time.Unix(100, 0))
+	writeCompleteCacheEntry(t, cacheDirectory, newKey, time.Unix(200, 0))
+
+	if err := pruneCacheEntries(cacheDirectory, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	assertCacheEntryExists(t, cacheDirectory, oldKey)
+	assertCacheEntryExists(t, cacheDirectory, newKey)
+}
+
+func TestPruneCacheEntriesIgnoresNonCacheFileGroups(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	oldKey := "0000000000000000000000000000000000000001"
+	newKey := "0000000000000000000000000000000000000002"
+	writeCompleteCacheEntry(t, cacheDirectory, oldKey, time.Unix(100, 0))
+	writeCompleteCacheEntry(t, cacheDirectory, newKey, time.Unix(200, 0))
+	writeCompleteCacheEntry(t, cacheDirectory, "not-a-cache-key", time.Unix(1, 0))
+
+	if err := pruneCacheEntries(cacheDirectory, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	assertCacheEntryRemoved(t, cacheDirectory, oldKey)
+	assertCacheEntryExists(t, cacheDirectory, newKey)
+	assertCacheEntryExists(t, cacheDirectory, "not-a-cache-key")
+}
+
+func writeCompleteCacheEntry(t *testing.T, cacheDirectory, key string, modTime time.Time) {
+	t.Helper()
+
+	for suffix, content := range map[string]string{
+		"":      "0",
+		"_out":  "stdout",
+		"_err":  "stderr",
+		"_mux":  "mux",
+		".lock": "",
+	} {
+		path := filepath.Join(cacheDirectory, key+suffix)
+		if err := os.WriteFile(path, []byte(content), 0666); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, modTime, modTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func writePartialCacheEntry(t *testing.T, cacheDirectory, key string, modTime time.Time) {
+	t.Helper()
+
+	for suffix, content := range map[string]string{
+		"":     "0",
+		"_out": "stdout",
+	} {
+		path := filepath.Join(cacheDirectory, key+suffix)
+		if err := os.WriteFile(path, []byte(content), 0666); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, modTime, modTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func assertCacheEntryExists(t *testing.T, cacheDirectory, key string) {
+	t.Helper()
+
+	for _, suffix := range []string{"", "_out", "_err", "_mux", ".lock"} {
+		if _, err := os.Stat(filepath.Join(cacheDirectory, key+suffix)); err != nil {
+			t.Fatalf("cache entry %s%s should exist: %v", key, suffix, err)
+		}
+	}
+}
+
+func assertCacheEntryRemoved(t *testing.T, cacheDirectory, key string) {
+	t.Helper()
+
+	for _, suffix := range []string{"", "_out", "_err", "_mux", ".lock"} {
+		if _, err := os.Stat(filepath.Join(cacheDirectory, key+suffix)); !os.IsNotExist(err) {
+			t.Fatalf("cache entry %s%s should be removed: %v", key, suffix, err)
+		}
+	}
+}
+
+func assertPartialCacheEntryExists(t *testing.T, cacheDirectory, key string) {
+	t.Helper()
+
+	for _, suffix := range []string{"", "_out"} {
+		if _, err := os.Stat(filepath.Join(cacheDirectory, key+suffix)); err != nil {
+			t.Fatalf("partial cache entry %s%s should exist: %v", key, suffix, err)
+		}
+	}
+	for _, suffix := range []string{"_err", "_mux", ".lock"} {
+		if _, err := os.Stat(filepath.Join(cacheDirectory, key+suffix)); !os.IsNotExist(err) {
+			t.Fatalf("partial cache entry %s%s should not exist: %v", key, suffix, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Summary
- Keep only the newest 1024 complete cache entries by default after each run.
- Add `--max-cache-entries` to tune pruning or disable it with `0`.
- Ignore partial and non-cache files when pruning.

Tests
- `gofmt -w main.go main_test.go`
- `go test -run 'Test(ParseMaxCacheEntries|IsCacheKey|MainRejectsInvalidMaxCacheEntries|PruneCacheEntries)' -count=1 ./...`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `go vet ./...`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `shellcheck bin/*.sh`
- `typos README.md main.go main_test.go`
- `go install`
- `docker build -f docker/server/Dockerfile .`
- `git diff --check`
