### PR TITLE
fix: check status file first in ReplayByCache to avoid unnecessary file opens

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,16 +237,8 @@ func (cc CommandCache) GetOrRun() (int, error) {
 }
 
 func (cc CommandCache) ReplayByCache() (int, error) {
-	outFile, err := os.Open(cc.OutFilepath)
-	if err != nil {
-		return 0, err
-	}
-	defer outFile.Close()
-	errFile, err := os.Open(cc.ErrFilepath)
-	if err != nil {
-		return 0, err
-	}
-	defer errFile.Close()
+	// Check the status file first: if it is absent or invalid, avoid opening
+	// the output files unnecessarily (cache-miss is the common case).
 	statusFile, err := os.Open(cc.StatusFilepath)
 	if err != nil {
 		return 0, err
@@ -269,6 +261,16 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 			return exitStatus, replayMux(muxFile)
 		}
 	}
+	outFile, err := os.Open(cc.OutFilepath)
+	if err != nil {
+		return 0, err
+	}
+	defer outFile.Close()
+	errFile, err := os.Open(cc.ErrFilepath)
+	if err != nil {
+		return 0, err
+	}
+	defer errFile.Close()
 	if _, err := io.Copy(os.Stdout, outFile); err != nil {
 		return 0, err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -527,6 +527,34 @@ func TestReplayByCacheRejectsInvalidStatus(t *testing.T) {
 	}
 }
 
+func TestReplayByCacheNoOutputOnInvalidStatus(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	cacheKey := "cache-key"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "echo unreachable"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+	}
+
+	for path, value := range map[string]string{
+		commandCache.StatusFilepath: "not-a-status",
+		commandCache.OutFilepath:    "cached stdout",
+		commandCache.ErrFilepath:    "cached stderr",
+	} {
+		if err := os.WriteFile(path, []byte(value), 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stdout, _ := captureStdoutDuring(t, func() {
+		_, _ = commandCache.ReplayByCache()
+	})
+	if stdout != "" {
+		t.Fatalf("ReplayByCache() wrote %q to stdout before status validation", stdout)
+	}
+}
+
 func TestRunAndCacheReturnsCommandStartError(t *testing.T) {
 	cacheDirectory := t.TempDir()
 	cacheKey := "cache-key"


### PR DESCRIPTION
## Summary

`ReplayByCache` opened `_out` and `_err` file descriptors before attempting
to open the status file. On every cache miss (the common case) the status
file is absent, so those two opens were wasted.

Reorder the function to open and validate the status file **first**. Only
if the status file exists and contains a valid exit-status integer are the
output files opened and replayed. An absent or corrupt status file returns
an error immediately without touching the output files.

## Changes

- `main.go`: reorder `ReplayByCache` — status file opened and parsed before
  `_out`/`_err` are opened.
- `main_test.go`: add `TestReplayByCacheNoOutputOnInvalidStatus` — asserts
  that no bytes reach stdout when the status file holds an invalid value.

## Verification

```
go test ./...
```

All existing tests continue to pass.
