### PR TITLE
fix: buffer replay output to prevent partial stdout on cache file read error

### DIFF
--- a/main.go
+++ b/main.go
@@ -261,20 +261,21 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 			return exitStatus, replayMux(muxFile)
 		}
 	}
-	outFile, err := os.Open(cc.OutFilepath)
+	// Buffer both output files before writing. If either read fails no bytes
+	// are written to stdout or stderr, so a fallback to RunAndCache cannot
+	// produce duplicate output.
+	outBuf, err := os.ReadFile(cc.OutFilepath)
 	if err != nil {
 		return 0, err
 	}
-	defer outFile.Close()
-	errFile, err := os.Open(cc.ErrFilepath)
+	errBuf, err := os.ReadFile(cc.ErrFilepath)
 	if err != nil {
 		return 0, err
 	}
-	defer errFile.Close()
-	if _, err := io.Copy(os.Stdout, outFile); err != nil {
+	if _, err := os.Stdout.Write(outBuf); err != nil {
 		return 0, err
 	}
-	if _, err := io.Copy(os.Stderr, errFile); err != nil {
+	if _, err := os.Stderr.Write(errBuf); err != nil {
 		return 0, err
 	}
 	return exitStatus, nil

--- a/main_test.go
+++ b/main_test.go
@@ -555,6 +555,38 @@ func TestReplayByCacheNoOutputOnInvalidStatus(t *testing.T) {
 	}
 }
 
+func TestReplayByCacheNoStdoutWhenErrFileMissing(t *testing.T) {
+	// When _err is absent the replay must fail without emitting any stdout.
+	// Before the buffering fix, io.Copy to stdout succeeded before the
+	// subsequent _err open failed, leaving stdout partially replayed and
+	// causing RunAndCache to produce a duplicate on fallback.
+	cacheDirectory := t.TempDir()
+	cacheKey := "cache-key"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "echo unreachable"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+	}
+
+	for path, value := range map[string]string{
+		commandCache.StatusFilepath: "0",
+		commandCache.OutFilepath:    "cached stdout content",
+		// ErrFilepath intentionally absent
+	} {
+		if err := os.WriteFile(path, []byte(value), 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stdout, _ := captureStdoutDuring(t, func() {
+		_, _ = commandCache.ReplayByCache()
+	})
+	if stdout != "" {
+		t.Fatalf("ReplayByCache() wrote %q to stdout when err file was missing", stdout)
+	}
+}
+
 func TestRunAndCacheReturnsCommandStartError(t *testing.T) {
 	cacheDirectory := t.TempDir()
 	cacheKey := "cache-key"


### PR DESCRIPTION
## Summary

`ReplayByCache` used streaming `io.Copy` to write stdout before reading the
error file. If opening or copying `_err` failed after `_out` was already
streamed, the function returned an error and `GetOrRun` fell back to
`RunAndCache`, which ran the command again — producing duplicate stdout.

Read both `_out` and `_err` into memory buffers first. If either read fails,
no bytes are written to stdout or stderr, so a `RunAndCache` fallback
produces a clean single run.

## Changes

- `main.go`: replace `os.Open` + `io.Copy` for output files with
  `os.ReadFile` into `[]byte` buffers; write both after all reads succeed.
- `main_test.go`: add `TestReplayByCacheNoStdoutWhenErrFileMissing` — asserts
  zero stdout bytes when `_err` is absent after a valid status file.

## Dependency

This branch is based on `fix/audit-state-machine-no-failure-state-001`
(PR #165) which reorders the status-file check to the top of `ReplayByCache`.
The base of this PR is set to that branch.

## Verification

```
go test ./...
```

All existing and new tests pass.
