### PR TITLE
Add cache status format marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ By default, `cmd_cache` keeps the newest 1024 complete cache entries in the
 cache directory and prunes older entries after each run. Set
 `--max-cache-entries=0` to disable pruning.
 
+## Cache compatibility
+
+New cache status files include a `cmd_cache status v1` header before the exit
+status. Existing cache entries that contain only a numeric exit status are still
+accepted for backward compatibility.
+
 ## Environment variable inheritance
 
 The cache key only includes the environment variables listed with `--env`.

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ Options:
  --max-cache-entries=COUNT      Maximum complete cache entries to keep; 0 disables pruning [default: 1024]
 `
 
+const cacheStatusHeader = "cmd_cache status v1\n"
+
 type CommandContext struct {
 	Command                  []string
 	Texts                    []string
@@ -248,7 +250,7 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	exitStatus, err := strconv.Atoi(string(exitStatusText))
+	exitStatus, err := parseCachedExitStatus(exitStatusText)
 	if err != nil {
 		return 0, fmt.Errorf("invalid cached exit status in %s (%q): %w", cc.StatusFilepath, string(exitStatusText), err)
 	}
@@ -311,6 +313,18 @@ func replayMux(r io.Reader) error {
 	}
 }
 
+func parseCachedExitStatus(content []byte) (int, error) {
+	text := string(content)
+	if strings.HasPrefix(text, cacheStatusHeader) {
+		return strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(text, cacheStatusHeader), "\n"))
+	}
+	return strconv.Atoi(text)
+}
+
+func formatCachedExitStatus(exitStatus int) []byte {
+	return []byte(cacheStatusHeader + strconv.Itoa(exitStatus) + "\n")
+}
+
 func (cc CommandCache) RunAndCache() (int, error) {
 	outFile, err := newCacheTempFile(cc.OutFilepath)
 	if err != nil {
@@ -369,7 +383,7 @@ func (cc CommandCache) RunAndCache() (int, error) {
 		return exitStatus, err
 	}
 	defer statusFile.Remove()
-	if _, err := statusFile.file.Write([]byte(strconv.Itoa(exitStatus))); err != nil {
+	if _, err := statusFile.file.Write(formatCachedExitStatus(exitStatus)); err != nil {
 		return exitStatus, err
 	}
 	if err := os.Remove(cc.StatusFilepath); err != nil && !os.IsNotExist(err) {

--- a/main_test.go
+++ b/main_test.go
@@ -456,7 +456,7 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 	}
 
 	for path, expected := range map[string]string{
-		commandCache.StatusFilepath: "0",
+		commandCache.StatusFilepath: string(formatCachedExitStatus(0)),
 		commandCache.OutFilepath:    "x",
 		commandCache.ErrFilepath:    "y",
 	} {
@@ -469,6 +469,33 @@ func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
 		}
 	}
 	assertNoCacheTempFiles(t, cacheDirectory)
+}
+
+func TestParseCachedExitStatusAcceptsVersionedStatus(t *testing.T) {
+	exitStatus, err := parseCachedExitStatus(formatCachedExitStatus(23))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitStatus != 23 {
+		t.Fatalf("exit status = %d, want 23", exitStatus)
+	}
+}
+
+func TestParseCachedExitStatusAcceptsLegacyStatus(t *testing.T) {
+	exitStatus, err := parseCachedExitStatus([]byte("0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitStatus != 0 {
+		t.Fatalf("exit status = %d, want 0", exitStatus)
+	}
+}
+
+func TestParseCachedExitStatusRejectsUnknownVersionedPayload(t *testing.T) {
+	_, err := parseCachedExitStatus([]byte("cmd_cache status v2\n0\n"))
+	if err == nil {
+		t.Fatal("parseCachedExitStatus accepted an unsupported versioned payload")
+	}
 }
 
 func TestRunAndCacheDoesNotCacheFailures(t *testing.T) {


### PR DESCRIPTION
## Summary
- Write cache status metadata with an explicit `cmd_cache status v1` marker.
- Continue reading legacy numeric status files.
- Reject unsupported versioned payloads instead of guessing at the format.

## Tests
- `gofmt -w main.go main_test.go`
- `go vet ./...`
- `shellcheck bin/*.sh`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `go install`
- `docker build -f docker/server/Dockerfile .`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
