### PR TITLE
Add concurrency to gitignore update workflow

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     # daily at 00:00
     - cron: '0 0 * * *'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary
- Add a top-level concurrency group to the scheduled gitignore update workflow.
- Reuse the existing workflow/ref group pattern used by the other workflows.
- Cancel an older scheduled update run when a newer one starts.

## Verification
- actionlint .github/workflows/gitignore-in.yml
- git diff --check
- go vet ./...
- go test ./...
