### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ $ go get -d ./...
 $ go build
 ```
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and register the hooks once:
+
+```console
+$ lefthook install
+```
+
+After that, on every commit the following check runs automatically:
+
+- **pre-commit**: `shellcheck bin/*.sh`, `go vet ./...`
+
+On every push the full local suite runs:
+
+- **pre-push**: `shellcheck bin/*.sh`, `go vet ./...`, `go test ./...`
+
+These hooks bring CI feedback earlier. The CI workflow still runs the full suite (including `-race -cover`) on every PR and push to main.
+
 ## LICENSE
 
 ### Source

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: shellcheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; shellcheck bin/*.sh
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+
+pre-push:
+  jobs:
+    - name: shellcheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; shellcheck bin/*.sh
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go test ./...


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` with pre-commit (`shellcheck bin/*.sh`, `go vet ./...`) and pre-push (`shellcheck bin/*.sh`, `go vet ./...`, `go test ./...`) hooks
- Add `## Development` section to `README.md` explaining `lefthook install` and what each hook runs
- CI workflow (`golang-test.yml`) is unchanged; the hooks bring the same checks to the local development loop

## Files changed

- `lefthook.yml` (new)
- `README.md` (Development section added before LICENSE)

## Test plan

- [x] `shellcheck bin/*.sh` passes locally
- [x] `go vet ./...` passes locally
- [x] `go test ./...` passes locally
- [x] Pre-commit hook fired and passed during commit
- [x] Pre-push hook fired and passed during push
- [ ] CI golang-test workflow passes on this PR
