### PR TITLE
Pin GoReleaser version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.26.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Summary:
- Pin the GoReleaser tool version used by the release workflow to v1.26.2.
- Keep the existing v1-compatible `release --rm-dist` invocation while removing `latest` drift.
- Make release output less dependent on future GoReleaser changes.

Tests:
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- shellcheck bin/*.sh
- typos
- go vet ./...
- go test ./...
- go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
- go build ./...
- go mod tidy && git diff --exit-code -- go.mod go.sum
- collateral check: clean
