### PR TITLE
fix: restrict cache directory and lock file permissions to owner-only

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func (cc CommandCache) GetOrRun() (int, error) {
 	}
 
 	lockPath := cc.StatusFilepath + ".lock"
-	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		// Lock file cannot be opened; fall back to running without a lock.
 		return cc.RunAndCache()
@@ -533,7 +533,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
 	}
-	if err := os.MkdirAll(cacheDirectory, 0755); err != nil {
+	if err := os.MkdirAll(cacheDirectory, 0700); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
 	}


### PR DESCRIPTION
## Summary

Restrict the cache directory and advisory lock file permissions to the owner only.

- `os.MkdirAll(cacheDirectory, 0755)` → `0700`: prevents other local users from listing cache keys (command fingerprinting via directory traversal)
- `os.OpenFile(lockPath, …, 0644)` → `0600`: prevents other local users from reading the lock file, which reveals which commands are currently in flight

Cache content files were already created via `os.CreateTemp` (mode 0600 by default), so no change is needed for those files.

## Impact

In shared-host, self-hosted CI runner, or multi-tenant container environments, other local users can no longer enumerate which commands were cached (via `ls` of the cache directory) or observe in-flight commands (via lock file presence).

Single-user workstations are unaffected.

## Verification

- `go test -race ./...` passes
- `staticcheck ./...` clean
- `go vet ./...` clean
