### PR TITLE
fix: replace unmaintained docopt-go with stdlib flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/kitsuyui/cmd_cache
 go 1.24.0
 
 toolchain go1.26.0
-
-require github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
-github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"flag"
 	"fmt"
 	"hash"
 	"io"
@@ -17,8 +18,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/docopt/docopt-go"
 )
 
 const COMMAND_USAGE = `cmd_cache
@@ -545,36 +544,83 @@ func pruneCacheEntries(cacheDirectory string, maxEntries int) error {
 var version string
 var exit = os.Exit
 
+// stringSlice accumulates repeated flag values (e.g. --file a --file b).
+type stringSlice []string
+
+func (s *stringSlice) String() string { return strings.Join(*s, ",") }
+func (s *stringSlice) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+type cliOptions struct {
+	cacheDirectory  string
+	maxCacheEntries string
+	showVersion     bool
+	files           []string
+	envVars         []string
+	texts           []string
+	command         []string
+}
+
+func parseCLI(args []string) (cliOptions, error) {
+	fs := flag.NewFlagSet("cmd_cache", flag.ContinueOnError)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, COMMAND_USAGE) }
+
+	var files, envVars, texts stringSlice
+	cacheDir := fs.String("cache-directory", ".cmd_cache", "Cache directory")
+	maxEntries := fs.String("max-cache-entries", "1024", "Maximum complete cache entries to keep; 0 disables pruning")
+	showVersion := fs.Bool("version", false, "Show version")
+	showVersionShort := fs.Bool("V", false, "Show version")
+	fs.Var(&files, "file", "Depending file under the current working directory (may be repeated)")
+	fs.Var(&envVars, "env", "Depending environment variable (may be repeated)")
+	fs.Var(&texts, "text", "Text affecting command (may be repeated)")
+
+	if err := fs.Parse(args); err != nil {
+		return cliOptions{}, err
+	}
+	return cliOptions{
+		cacheDirectory:  *cacheDir,
+		maxCacheEntries: *maxEntries,
+		showVersion:     *showVersion || *showVersionShort,
+		files:           []string(files),
+		envVars:         []string(envVars),
+		texts:           []string(texts),
+		command:         fs.Args(),
+	}, nil
+}
+
 func main() {
-	parser := &docopt.Parser{HelpHandler: docopt.PrintHelpOnly}
-	opts, err := parser.ParseArgs(COMMAND_USAGE, nil, "")
+	opts, err := parseCLI(os.Args[1:])
 	if err != nil {
+		if err == flag.ErrHelp {
+			return
+		}
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
 		return
 	}
-	if opts == nil {
-		return
-	}
-	if showVersion, _ := opts.Bool("--version"); showVersion {
+	if opts.showVersion {
 		fmt.Println(version)
 		return
 	}
-	cacheDirectory := opts["--cache-directory"].(string)
-	maxCacheEntries, err := parseMaxCacheEntries(opts["--max-cache-entries"].(string))
+	cacheDirectory := opts.cacheDirectory
+	maxCacheEntries, err := parseMaxCacheEntries(opts.maxCacheEntries)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
+		return
 	}
 	if err := os.MkdirAll(cacheDirectory, 0755); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
+		return
 	}
 	if err := cleanOrphanedTempFiles(cacheDirectory, time.Hour); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
 
-	commands := opts["COMMAND"].([]string)
+	commands := opts.command
 	if len(commands) == 0 {
 		fmt.Fprintln(os.Stderr, "COMMAND is required")
 		exit(1)
@@ -582,9 +628,9 @@ func main() {
 	}
 	commandContext := CommandContext{
 		Command:                  commands,
-		Texts:                    opts["TEXT"].([]string),
-		EnvironmentVariableNames: opts["ENV"].([]string),
-		Filenames:                opts["FILE"].([]string),
+		Texts:                    opts.texts,
+		EnvironmentVariableNames: opts.envVars,
+		Filenames:                opts.files,
 	}
 
 	h := sha1.New()

--- a/main_test.go
+++ b/main_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	docopt "github.com/docopt/docopt-go"
 )
 
 func TestMain(t *testing.T) {
@@ -33,31 +31,26 @@ func TestMain(t *testing.T) {
 	main()
 }
 
-func TestDocopt(t *testing.T) {
-	_, err := docopt.ParseArgs(COMMAND_USAGE, []string{
-		"--file", "test.txt", "--", "ls", "-ahl",
-	}, "")
+func TestParseCLIFile(t *testing.T) {
+	opts, err := parseCLI([]string{"--file", "test.txt", "--", "ls", "-ahl"})
 	if err != nil {
-		t.Error("Document for docopt has broken")
+		t.Fatalf("parseCLI returned error: %v", err)
+	}
+	if len(opts.files) != 1 || opts.files[0] != "test.txt" {
+		t.Errorf("files = %v, want [test.txt]", opts.files)
+	}
+	if len(opts.command) == 0 || opts.command[0] != "ls" {
+		t.Errorf("command = %v, want [ls ...]", opts.command)
 	}
 }
 
-func TestDocoptRejectsMissingCommand(t *testing.T) {
-	parser := &docopt.Parser{HelpHandler: docopt.NoHelpHandler}
-	_, err := parser.ParseArgs(COMMAND_USAGE, []string{
-		"--file", "test.txt", "--",
-	}, "")
-	if err == nil {
-		t.Fatal("docopt accepted a missing command")
-	}
-}
-
-func TestVersion(t *testing.T) {
-	_, err := docopt.ParseArgs(COMMAND_USAGE, []string{
-		"--version",
-	}, "")
+func TestParseCLIVersion(t *testing.T) {
+	opts, err := parseCLI([]string{"--version"})
 	if err != nil {
-		t.Error("Document for docopt has broken")
+		t.Fatalf("parseCLI returned error: %v", err)
+	}
+	if !opts.showVersion {
+		t.Error("showVersion should be true for --version flag")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove `github.com/docopt/docopt-go` (last upstream commit 2018-01-11, no tagged releases) as the sole third-party dependency.
- Replace with Go standard library `flag` package using a custom `stringSlice` type for repeatable `--file`/`--env`/`--text` flags.
- CLI behavior is preserved: `--cache-directory`, `--max-cache-entries`, `--file`/`--env`/`--text` (repeatable, order-independent), `--`, and `--version`/`-V` all work identically.

## Why

`docopt-go` has had no upstream activity since 2018 and uses a pseudo-version (`v0.0.0-20180111231733-ee0de3bc6815`). As the only CLI argument parser, it represents the sole third-party supply chain entry point. The `flag` standard library covers all needed patterns without adding any dependency.

## Verification

- `go build ./...`: clean
- `go test ./...`: all tests pass
- `go vet ./...`: clean
- `staticcheck ./...`: 0 findings
- Collateral check: clean