### PR TITLE
fix: remove advisory lock file after cache write completes

### DIFF
--- a/main.go
+++ b/main.go
@@ -222,6 +222,7 @@ func (cc CommandCache) GetOrRun() (int, error) {
 		// Lock file cannot be opened; fall back to running without a lock.
 		return cc.RunAndCache()
 	}
+	defer os.Remove(lockPath) // remove after Close (LIFO: registered first, runs last)
 	defer lockFile.Close()
 
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {


### PR DESCRIPTION
## Summary

`GetOrRun` acquires an advisory lock file (`{hash}.lock`) to prevent thundering herd
on cache miss, but previously only closed the file descriptor via `defer lockFile.Close()`
without removing the file from disk. Lock files were only cleaned up when
`pruneCacheEntries` happened to delete the matching cache entry.

**Before:** `.lock` files accumulated indefinitely. With `--max-cache-entries=0`
every unique cache key left a permanent `.lock` file consuming an inode. With pruning
enabled, up to N lock files (one per retained entry) remained on disk at all times.

**After:** `defer os.Remove(lockPath)` is registered before `defer lockFile.Close()`.
LIFO defer ordering runs: unlock → close → remove. The lock file is removed as soon
as `GetOrRun` returns, regardless of whether the cache write succeeded.

## Behavior notes

- `os.Remove` on an already-deleted path (race with another concurrent process) is
  silently ignored (returns `ENOENT` which is not checked — conventional for cleanup defers).
- Concurrent processes that already hold an open file descriptor to the same inode
  when the path is unlinked retain their flock until they close the fd; the thundering-herd
  guarantee is not broken.
- The fast-path `ReplayByCache()` check at the top of `GetOrRun` means a process that
  races through a just-removed lock file path will find the cache populated and return
  without acquiring a new flock.

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` passes (0 findings)
- [x] `check-pr-collateral.py` clean