### PR TITLE
fix: exit with non-zero status when cache write fails after command success

### DIFF
--- a/main.go
+++ b/main.go
@@ -564,6 +564,9 @@ func main() {
 	exitStatus, err := commandCache.GetOrRun()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		if exitStatus == 0 {
+			exitStatus = 1 // cache infrastructure failure must not exit 0
+		}
 	}
 	if pruneErr := pruneCacheEntries(cacheDirectory, maxCacheEntries); pruneErr != nil {
 		fmt.Fprintln(os.Stderr, pruneErr)


### PR DESCRIPTION
## Summary

When the wrapped command exits 0 but cmd_cache fails to write the cache
(disk full, permission error, rename failure, etc.), `RunAndCache` returns
`(exitStatus=0, err!=nil)`. Previously `main` printed the error to stderr but
still called `exit(0)`, so callers that only check the exit code had no way to
detect the infrastructure failure.

**Before:**
```
$ cmd_cache -- true  # disk full → stderr shows error but exits 0
```

**After:**
```
$ cmd_cache -- true  # disk full → stderr shows error, exits 1
```

Automation relying on exit-code-only checks (CI scripts, Makefiles) would
silently proceed after the failure, then re-execute the command on the next
invocation because no cache entry was written — contrary to the expectation
that exit 0 signals a completed, cached run.

## Change

In `main`, when `GetOrRun` returns `(exitStatus=0, err!=nil)`, set
`exitStatus = 1`. The wrapped command's own non-zero exit codes are preserved.

## Behaviour notes

- Wrapped command succeeds + cache write succeeds → exits 0 (unchanged)
- Wrapped command fails → exits with command's code (unchanged)
- Wrapped command succeeds + cache write fails → exits **1** (fixed)
- `pruneCacheEntries` failure is still printed to stderr but does not affect
  exit status (pruning is best-effort and is not part of the caching contract)

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` passes (0 findings)
- [x] `check-pr-collateral.py` clean