### PR TITLE
docs: document working directory inheritance for cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ cmd_cache --env PATH --env LANG -- my-command
 Shared cache directories across machines or CI environments with different
 `PATH` or locale settings can produce stale replays from a cache hit.
 
+## Working directory inheritance
+
+The cache key does not include the current working directory (CWD). The
+wrapped command inherits the CWD of the `cmd_cache` process, but this
+CWD is not factored into the cache key.
+
+This means that CWD-sensitive commands — such as `ls`, `make`,
+`go build`, or `git status` — can produce a cache hit across different
+directories. The first cached result will be replayed regardless of
+which directory `cmd_cache` was invoked from.
+
+If the wrapped command's output depends on the CWD, include it
+explicitly in the cache key:
+
+```sh
+cmd_cache --text "$PWD" -- ls
+```
+
+This mirrors the [`--env`](#environment-variable-inheritance) pattern
+for environment variables: any implicit dependency on the runtime
+environment must be declared explicitly to get a correct cache key.
+
 ## Time-dependent commands
 
 `cmd_cache` does not expire entries by time. There is no TTL, `--max-age`, or


### PR DESCRIPTION
## Summary

Add a "Working directory inheritance" section to README.md documenting
that the cache key does not include the current working directory (CWD).

## Why

The wrapped command inherits the caller's CWD but CWD is not part of
the cache key. CWD-sensitive commands (`ls`, `make`, `go build`,
`git status`, etc.) can therefore produce a stale cache hit when
`cmd_cache` is invoked from different directories.

The existing "Environment variable inheritance" section documents the
analogous gap for environment variables. This PR adds the equivalent
note for CWD — including the `--text "$PWD"` workaround — to make the
two implicit runtime dependencies symmetric in the documentation.

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` passes (0 findings)
- [x] PR collateral check: no violations
