### PR TITLE
Clean up orphaned temp files left by SIGKILL

### DIFF
--- a/main.go
+++ b/main.go
@@ -490,6 +490,34 @@ func collectCompleteCacheEntries(cacheDirectory string) ([]cacheEntry, error) {
 	return entries, nil
 }
 
+// cleanOrphanedTempFiles removes `.*.tmp-*` files in cacheDirectory that are
+// older than minAge. Files younger than minAge may still belong to a concurrent
+// RunAndCache invocation and are left untouched.
+func cleanOrphanedTempFiles(cacheDirectory string, minAge time.Duration) error {
+	matches, err := filepath.Glob(filepath.Join(cacheDirectory, ".*.tmp-*"))
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, path := range matches {
+		info, err := os.Lstat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			errs = append(errs, err)
+			continue
+		}
+		if time.Since(info.ModTime()) < minAge {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func pruneCacheEntries(cacheDirectory string, maxEntries int) error {
 	if maxEntries <= 0 {
 		return nil
@@ -536,6 +564,9 @@ func main() {
 	if err := os.MkdirAll(cacheDirectory, 0755); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
+	}
+	if err := cleanOrphanedTempFiles(cacheDirectory, time.Hour); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 	}
 
 	commands := opts["COMMAND"].([]string)

--- a/main_test.go
+++ b/main_test.go
@@ -935,3 +935,36 @@ func assertNoCacheTempFiles(t *testing.T, cacheDirectory string) {
 		t.Fatalf("temporary cache files were not cleaned up: %v", matches)
 	}
 }
+
+func TestCleanOrphanedTempFilesRemovesOldFiles(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	names := []string{".abc.tmp-11111", ".def.tmp-22222"}
+	for _, name := range names {
+		path := filepath.Join(cacheDirectory, name)
+		if err := os.WriteFile(path, []byte("orphan"), 0666); err != nil {
+			t.Fatal(err)
+		}
+		oldTime := time.Now().Add(-2 * time.Hour)
+		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cleanOrphanedTempFiles(cacheDirectory, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	assertNoCacheTempFiles(t, cacheDirectory)
+}
+
+func TestCleanOrphanedTempFilesPreservesRecentFiles(t *testing.T) {
+	cacheDirectory := t.TempDir()
+	path := filepath.Join(cacheDirectory, ".recent.tmp-12345")
+	if err := os.WriteFile(path, []byte("active"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanOrphanedTempFiles(cacheDirectory, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("recent temp file must not be removed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Add `cleanOrphanedTempFiles` to remove `.*.tmp-*` files left in the cache directory when a previous `cmd_cache` process was killed with SIGKILL. Because SIGKILL does not run `defer` statements, the temporary files created by `RunAndCache` (`outFile`, `errFile`, `muxFile`, `statusFile`) can accumulate indefinitely. `pruneCacheEntries` and `collectCompleteCacheEntries` both skip these files (their names fail `isCacheKey`), so no existing cleanup path removes them.

## Changes

**`main.go`**
- Add `cleanOrphanedTempFiles(cacheDirectory string, minAge time.Duration) error`:
  - Globs for `.*.tmp-*` in `cacheDirectory`
  - Skips files younger than `minAge` (avoids racing with a concurrent `RunAndCache`)
  - Removes the rest; tolerates `ENOENT` from concurrent removal
- Call `cleanOrphanedTempFiles(cacheDirectory, time.Hour)` in `main()` after `MkdirAll`

**`main_test.go`**
- `TestCleanOrphanedTempFilesRemovesOldFiles`: orphan files older than 2 h are removed
- `TestCleanOrphanedTempFilesPreservesRecentFiles`: files younger than 1 h are kept

## Verification

- `go vet ./...` — clean
- `go test -race ./...` — all tests pass
- `staticcheck ./...` — 0 findings
- collateral check — clean

## Trade-offs

The 1-hour `minAge` threshold means orphaned files from very recent SIGKILL events are not removed until the next invocation after an hour. This is intentional: a smaller window increases the risk of removing a temp file still held by a concurrent process.
