### PR TITLE
fix: buffer mux frames before writing to prevent partial output on truncation

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,13 +284,21 @@ func (cc CommandCache) ReplayByCache() (int, error) {
 }
 
 // replayMux reads a mux stream written by muxWriter and dispatches each frame
-// to os.Stdout (stream_id=1) or os.Stderr (stream_id=2).
+// to os.Stdout (stream_id=1) or os.Stderr (stream_id=2). All frames are buffered
+// in memory before any write so that a truncated or corrupt stream does not produce
+// partial output: if reading fails, nothing is written to stdout/stderr and a
+// fallback to RunAndCache cannot produce duplicate output.
 func replayMux(r io.Reader) error {
+	type frame struct {
+		stream byte
+		data   []byte
+	}
+	var frames []frame
 	var header [5]byte
 	for {
 		if _, err := io.ReadFull(r, header[:]); err != nil {
 			if err == io.EOF {
-				return nil
+				break
 			}
 			return fmt.Errorf("reading mux header: %w", err)
 		}
@@ -300,17 +308,21 @@ func replayMux(r io.Reader) error {
 		if _, err := io.ReadFull(r, data); err != nil {
 			return fmt.Errorf("reading mux data: %w", err)
 		}
-		switch stream {
+		frames = append(frames, frame{stream: stream, data: data})
+	}
+	for _, f := range frames {
+		switch f.stream {
 		case 1:
-			if _, err := os.Stdout.Write(data); err != nil {
+			if _, err := os.Stdout.Write(f.data); err != nil {
 				return err
 			}
 		case 2:
-			if _, err := os.Stderr.Write(data); err != nil {
+			if _, err := os.Stderr.Write(f.data); err != nil {
 				return err
 			}
 		}
 	}
+	return nil
 }
 
 func parseCachedExitStatus(content []byte) (int, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -614,6 +614,47 @@ func TestReplayByCacheNoStdoutWhenErrFileMissing(t *testing.T) {
 	}
 }
 
+func TestReplayMuxNoStdoutOnTruncatedMuxFile(t *testing.T) {
+	// A truncated mux file must not produce any stdout/stderr output before the
+	// read error is detected. Previously replayMux wrote frames incrementally;
+	// a partial read could emit output to stdout and then return an error, causing
+	// GetOrRun to fall back to RunAndCache and produce duplicate output.
+	cacheDirectory := t.TempDir()
+	cacheKey := "mux-truncated-test"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "echo unreachable"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+		MuxFilepath:    filepath.Join(cacheDirectory, cacheKey+"_mux"),
+	}
+
+	// Build a mux file with one valid frame followed by a truncated frame header.
+	frame1Data := []byte("hello")
+	var muxData []byte
+	muxData = append(muxData, 1, 0, 0, 0, byte(len(frame1Data))) // frame 1 header: stdout, len=5
+	muxData = append(muxData, frame1Data...)
+	muxData = append(muxData, 1, 0, 0) // truncated frame 2 header (3 of 5 bytes)
+
+	for path, content := range map[string][]byte{
+		commandCache.StatusFilepath: []byte("0"),
+		commandCache.OutFilepath:    []byte("cached stdout"),
+		commandCache.ErrFilepath:    []byte("cached stderr"),
+		commandCache.MuxFilepath:    muxData,
+	} {
+		if err := os.WriteFile(path, content, 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stdout, _ := captureStdoutDuring(t, func() {
+		_, _ = commandCache.ReplayByCache()
+	})
+	if stdout != "" {
+		t.Fatalf("ReplayByCache() wrote %q to stdout on truncated mux file", stdout)
+	}
+}
+
 func TestRunAndCacheReturnsCommandStartError(t *testing.T) {
 	cacheDirectory := t.TempDir()
 	cacheKey := "cache-key"


### PR DESCRIPTION
## Problem

`replayMux` wrote each frame to stdout/stderr immediately as it was read from
the mux file. If the mux file was truncated mid-stream (e.g. due to a disk fault
or interrupted write), some frames were already written to stdout before the read
error was returned.

`GetOrRun` detects the error and falls back to `RunAndCache`, which re-runs the
command and produces the same output — resulting in **duplicate output** visible
to the caller.

The `_out`/`_err` sequential path already had protection against this: it reads
both files entirely into memory before writing anything (added in PR #166 /
`audit-state-machine-partial-replay-double-output-001`). The mux path did not
have equivalent protection.

## Change

Buffer all frames in memory during the read loop. Only after every frame is
successfully read are they written to stdout/stderr. If reading fails at any
point, no bytes reach the output streams and a `RunAndCache` fallback cannot
produce duplicate output.

## Verification

Added `TestReplayMuxNoStdoutOnTruncatedMuxFile`: builds a mux file with one
valid frame followed by a truncated frame header, then asserts that
`ReplayByCache` writes nothing to stdout when the read error is detected.

All existing tests pass (`go test -race ./...`). `go vet ./...` clean.
