### PR TITLE
fix: return error for unknown stream_id in replayMux instead of silently dropping

### DIFF
--- a/main.go
+++ b/main.go
@@ -309,6 +309,8 @@ func replayMux(r io.Reader) error {
 			if _, err := os.Stderr.Write(data); err != nil {
 				return err
 			}
+		default:
+			return fmt.Errorf("unknown stream_id %d in mux frame", stream)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -614,6 +614,47 @@ func TestReplayByCacheNoStdoutWhenErrFileMissing(t *testing.T) {
 	}
 }
 
+func TestReplayMuxRejectsUnknownStreamID(t *testing.T) {
+	// A frame with stream_id other than 1 or 2 must cause replayMux to return an
+	// error rather than silently dropping the frame and reporting success. Silent
+	// drops cause the caller to treat a corrupt mux file as valid, so the cached
+	// output diverges from what the command actually produced.
+	cacheDirectory := t.TempDir()
+	cacheKey := "mux-unknown-stream-test"
+	commandCache := CommandCache{
+		Command:        []string{"sh", "-c", "echo unreachable"},
+		StatusFilepath: filepath.Join(cacheDirectory, cacheKey),
+		OutFilepath:    filepath.Join(cacheDirectory, cacheKey+"_out"),
+		ErrFilepath:    filepath.Join(cacheDirectory, cacheKey+"_err"),
+		MuxFilepath:    filepath.Join(cacheDirectory, cacheKey+"_mux"),
+	}
+
+	// Build a mux file with one frame that has an unknown stream_id (3).
+	unknownData := []byte("dropped-data")
+	var muxData []byte
+	muxData = append(muxData, 3, 0, 0, 0, byte(len(unknownData))) // stream_id=3 (invalid)
+	muxData = append(muxData, unknownData...)
+
+	for path, content := range map[string][]byte{
+		commandCache.StatusFilepath: []byte("0"),
+		commandCache.OutFilepath:    []byte("cached stdout"),
+		commandCache.ErrFilepath:    []byte("cached stderr"),
+		commandCache.MuxFilepath:    muxData,
+	} {
+		if err := os.WriteFile(path, content, 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := commandCache.ReplayByCache()
+	if err == nil {
+		t.Fatal("ReplayByCache() returned nil error for unknown stream_id in mux file")
+	}
+	if !strings.Contains(err.Error(), "unknown stream_id") {
+		t.Fatalf("error %q does not mention unknown stream_id", err.Error())
+	}
+}
+
 func TestRunAndCacheReturnsCommandStartError(t *testing.T) {
 	cacheDirectory := t.TempDir()
 	cacheKey := "cache-key"


### PR DESCRIPTION
## Problem

`replayMux` had no `default` case in its `switch stream` statement. A mux frame
with an unknown `stream_id` (anything other than 1 for stdout or 2 for stderr)
was silently skipped — its data was consumed from the reader but never written to
either output stream.

`replayMux` returned `nil` (success), giving `GetOrRun` no signal that output
was missing. The caller then treated the corrupt cache as valid, so the command's
actual output and the cached replay diverged silently.

This can occur if the mux file is corrupted by a disk fault, partial write, or
bit flip that alters the `stream_id` byte of a frame.

## Change

Add a `default` case that returns `fmt.Errorf("unknown stream_id %d in mux frame", stream)`.
`ReplayByCache` propagates this error to `GetOrRun`, which falls back to
`RunAndCache` to re-run the command with correct output.

## Verification

Added `TestReplayMuxRejectsUnknownStreamID`: writes a mux file with a single
frame whose `stream_id` is 3 (invalid) and asserts that `ReplayByCache` returns
a non-nil error containing `"unknown stream_id"`.

All existing tests pass (`go test -race ./...`). `go vet ./...` clean.
