### PR TITLE
Bound per-frame allocation in replayMux

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,13 @@ Options:
 
 const cacheStatusHeader = "cmd_cache status v1\n"
 
+// maxMuxFrameLength caps the per-frame allocation in replayMux.
+// Subprocess output arrives through OS pipes whose write-side buffer is
+// typically ~64 KiB, so legitimate frames are far below this limit.
+// A corrupted or adversarial _mux file could otherwise trigger a multi-GiB
+// allocation via the raw uint32 frame-length field.
+const maxMuxFrameLength = 64 * 1024 * 1024 // 64 MiB
+
 type CommandContext struct {
 	Command                  []string
 	Texts                    []string
@@ -296,6 +303,9 @@ func replayMux(r io.Reader) error {
 		}
 		stream := header[0]
 		length := binary.BigEndian.Uint32(header[1:])
+		if length > maxMuxFrameLength {
+			return fmt.Errorf("mux frame length %d exceeds maximum %d: cache file may be corrupt", length, maxMuxFrameLength)
+		}
 		data := make([]byte, length)
 		if _, err := io.ReadFull(r, data); err != nil {
 			return fmt.Errorf("reading mux data: %w", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha1"
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"log"
@@ -933,5 +935,35 @@ func assertNoCacheTempFiles(t *testing.T, cacheDirectory string) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("temporary cache files were not cleaned up: %v", matches)
+	}
+}
+
+func TestReplayMuxRejectsOversizedFrame(t *testing.T) {
+	var buf bytes.Buffer
+	var header [5]byte
+	header[0] = 1 // stream stdout
+	binary.BigEndian.PutUint32(header[1:], maxMuxFrameLength+1)
+	buf.Write(header[:])
+
+	err := replayMux(&buf)
+	if err == nil {
+		t.Fatal("replayMux() returned nil for a frame exceeding maxMuxFrameLength")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Errorf("error message %q does not mention 'exceeds maximum'", err.Error())
+	}
+}
+
+func TestReplayMuxAcceptsMaxSizeFrame(t *testing.T) {
+	var buf bytes.Buffer
+	var header [5]byte
+	header[0] = 1 // stream stdout
+	binary.BigEndian.PutUint32(header[1:], maxMuxFrameLength)
+	buf.Write(header[:])
+	buf.Write(make([]byte, maxMuxFrameLength))
+
+	err := replayMux(&buf)
+	if err != nil {
+		t.Fatalf("replayMux() returned unexpected error for max-size frame: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`replayMux` reads a frame-length field (4-byte big-endian uint32) from a
`_mux` cache file and passes it directly to `make([]byte, length)` without
an upper bound. A corrupted or crafted `_mux` file with `length = 0xFFFFFFFF`
would trigger a ~4 GiB allocation, causing OOM or panic that bypasses normal
error handling.

## Change

- Add `maxMuxFrameLength = 64 MiB` constant near `cacheStatusHeader`.
- In `replayMux`, reject frames that exceed the limit with a descriptive error
  before calling `make`.
- Add two unit tests: one for the reject path and one confirming that
  exactly-max-size frames are accepted.

```diff
+const maxMuxFrameLength = 64 * 1024 * 1024 // 64 MiB

  stream := header[0]
  length := binary.BigEndian.Uint32(header[1:])
+ if length > maxMuxFrameLength {
+     return fmt.Errorf("mux frame length %d exceeds maximum %d: cache file may be corrupt", length, maxMuxFrameLength)
+ }
  data := make([]byte, length)
```

## Why 64 MiB

Subprocess output reaches the mux writer through OS pipe reads. Each pipe
write is bounded by the OS pipe buffer (~64 KiB on Linux/macOS). So a
single legitimate frame is always far below 64 MiB. The 64 MiB limit
provides a generous safety margin for future in-process tests or
non-pipe sources while still preventing multi-GiB allocations.

## Verification

- `go fmt ./...` — no changes
- `go vet ./...` — clean
- `go test -race ./...` — all tests pass (including new `TestReplayMux*`)