### PR TITLE
Extract syscall.Flock to platform-specific files

### DIFF
--- a/lock_unix.go
+++ b/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func flockExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+func flockUnlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/lock_windows.go
+++ b/lock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+// flockExclusive returns an error on Windows because syscall.Flock is not
+// available. The caller falls back to running without a lock.
+func flockExclusive(f *os.File) error {
+	return errors.ErrUnsupported
+}
+
+// flockUnlock is a no-op on Windows.
+func flockUnlock(f *os.File) error {
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/docopt/docopt-go"
@@ -224,11 +223,11 @@ func (cc CommandCache) GetOrRun() (int, error) {
 	}
 	defer lockFile.Close()
 
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-		// flock failed; fall back to running without a lock.
+	if err := flockExclusive(lockFile); err != nil {
+		// flock failed or unavailable; fall back to running without a lock.
 		return cc.RunAndCache()
 	}
-	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	defer flockUnlock(lockFile)
 
 	// Double-check: another process may have written the cache while we waited.
 	if exitStatus, err := cc.ReplayByCache(); err == nil {


### PR DESCRIPTION
## Summary

`main.go` imported `syscall` and called `syscall.Flock` / `syscall.LOCK_EX` /
`syscall.LOCK_UN` directly inside `GetOrRun`. `syscall.Flock` is undefined on
Windows, so `GOOS=windows go build` and
`docker buildx build --platform=windows/amd64` failed with:

```
undefined: syscall.Flock
```

No build constraint or documentation indicated that Windows was unsupported.

## Change

Extract the two flock calls into build-constrained helper files:

| file | build tag | behaviour |
|---|---|---|
| `lock_unix.go` | `!windows` | wraps `syscall.Flock(LOCK_EX)` / `LOCK_UN` |
| `lock_windows.go` | `windows` | `flockExclusive` returns `errors.ErrUnsupported`; `flockUnlock` is a no-op |

`main.go` now calls `flockExclusive(lockFile)` / `flockUnlock(lockFile)` and
no longer imports `syscall`. The existing fallback in `GetOrRun` handles the
error from `flockExclusive` on Windows:

```go
if err := flockExclusive(lockFile); err != nil {
    // flock failed or unavailable; fall back to running without a lock.
    return cc.RunAndCache()
}
```

This preserves existing behaviour on Unix (exclusive locking) and gives
Windows users a working binary that runs without advisory locking.

## Verification

- `go fmt ./...` — no changes
- `go vet ./...` — clean
- `go test -race ./...` — all tests pass
- `GOOS=windows GOARCH=amd64 go build ./...` — succeeds (was: compile error)