### PR TITLE
fix: roll back committed cache files on partial rename failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,6 +205,29 @@ func (f *cacheTempFile) Rename() error {
 	return nil
 }
 
+func (f *cacheTempFile) RemoveFinalPath() {
+	_ = os.Remove(f.finalPath)
+}
+
+// commitCacheFiles renames each file in order; on failure, it rolls back the
+// already-committed renames so no partial cache entries are left on disk.
+func commitCacheFiles(files ...*cacheTempFile) error {
+	committed := make([]*cacheTempFile, 0, len(files))
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		if err := f.Rename(); err != nil {
+			for _, c := range committed {
+				c.RemoveFinalPath()
+			}
+			return err
+		}
+		committed = append(committed, f)
+	}
+	return nil
+}
+
 // GetOrRun returns the cached result if available. On a cache miss it acquires
 // an exclusive advisory lock on a per-cache-key lock file, re-checks the cache
 // (another process may have populated it while we waited), and runs the command
@@ -389,19 +412,8 @@ func (cc CommandCache) RunAndCache() (int, error) {
 	if err := os.Remove(cc.StatusFilepath); err != nil && !os.IsNotExist(err) {
 		return exitStatus, err
 	}
-	if err := outFile.Rename(); err != nil {
+	if err := commitCacheFiles(outFile, errFile, statusFile, muxFile); err != nil {
 		return exitStatus, err
-	}
-	if err := errFile.Rename(); err != nil {
-		return exitStatus, err
-	}
-	if err := statusFile.Rename(); err != nil {
-		return exitStatus, err
-	}
-	if muxFile != nil {
-		if err := muxFile.Rename(); err != nil {
-			return exitStatus, err
-		}
 	}
 	return exitStatus, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -935,3 +935,42 @@ func assertNoCacheTempFiles(t *testing.T, cacheDirectory string) {
 		t.Fatalf("temporary cache files were not cleaned up: %v", matches)
 	}
 }
+func TestCommitCacheFilesRollsBackOnFailure(t *testing.T) {
+	// Verify that commitCacheFiles removes already-committed files when a later
+	// rename fails, leaving no orphaned cache files on disk.
+	dir := t.TempDir()
+
+	// Prepare two temp files with distinct final paths.
+	finalOut := filepath.Join(dir, "abc_out")
+	finalErr := filepath.Join(dir, "abc_err")
+
+	outFile, err := newCacheTempFile(finalOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFile.Remove()
+	errFile, err := newCacheTempFile(finalErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer errFile.Remove()
+
+	// Block finalErr rename by placing a non-empty directory at that path.
+	if err := os.MkdirAll(finalErr, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Put a file inside so the directory is non-empty (some OS refuse rename over non-empty dir).
+	if err := os.WriteFile(filepath.Join(finalErr, "block"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// commitCacheFiles must fail and must NOT leave finalOut on disk.
+	commitErr := commitCacheFiles(outFile, errFile)
+	if commitErr == nil {
+		t.Fatal("commitCacheFiles should have returned an error")
+	}
+
+	if _, err := os.Stat(finalOut); !os.IsNotExist(err) {
+		t.Fatalf("commitCacheFiles left orphaned file %s after rollback", finalOut)
+	}
+}


### PR DESCRIPTION
## Problem

In `RunAndCache()`, cache files were committed (renamed from temp paths to
final paths) in sequence: `_out` → `_err` → status → `_mux`. If the first
rename succeeded but a later one failed (e.g. due to a full disk, permission
change, or concurrent removal), the already-renamed `{cacheKey}_out` file
was left orphaned on disk with no mechanism to clean it up:

- `defer outFile.Remove()` becomes a no-op after `Rename()` clears `path`.
- `collectCompleteCacheEntries` skips files with the `_out` suffix as scan
  anchors, so the orphan is never included in pruning.

The result is unbounded disk growth from partially-committed cache entries.

## Changes

- **`cacheTempFile.RemoveFinalPath()`** — removes the file at `finalPath`
  (the path that `Rename()` moves the temp file to).
- **`commitCacheFiles(...*cacheTempFile) error`** — renames each file in
  order; if any rename fails it removes all files that were already renamed
  in this call, then returns the error. `nil` entries are skipped so the
  optional `muxFile` can be passed directly.
- **`RunAndCache()`** — replaces the four separate `Rename()` calls with a
  single `commitCacheFiles(outFile, errFile, statusFile, muxFile)` call.

## Verification

- All existing tests continue to pass (`go test ./...`).
- `go vet ./...` reports no issues.
- New test `TestCommitCacheFilesRollsBackOnFailure` verifies that when the
  second rename fails (blocked by a pre-existing directory at the target
  path), the first file is removed and no orphan is left on disk.

## Trade-offs

The rollback is best-effort: `RemoveFinalPath()` silently ignores errors
(matching the existing `Remove()` convention in this codebase). In the
unlikely event that rollback itself fails (e.g. permissions revoked between
rename and remove), the file may still be left on disk — but this is no
worse than the previous behavior and is considerably less likely.