### PR TITLE
feat: add workflow to configure required status checks on main branch

### DIFF
--- a/.github/workflows/configure-branch-protection.yml
+++ b/.github/workflows/configure-branch-protection.yml
@@ -1,0 +1,18 @@
+name: configure-branch-protection
+
+on:
+  workflow_dispatch:
+
+permissions:
+  administration: write
+
+jobs:
+  configure:
+    name: configure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add test as required status check on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/configure-branch-protection.sh

--- a/scripts/configure-branch-protection.sh
+++ b/scripts/configure-branch-protection.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-kitsuyui/cmd_cache}"
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
+cat > "$tmpfile" <<'JSON'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["test"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+
+gh api "repos/${repo}/branches/main/protection" \
+  --method PUT \
+  --header "Content-Type: application/json" \
+  --input "$tmpfile"


### PR DESCRIPTION
## Summary

Branch protection on `main` has `required_status_checks.checks: []`, so the `test` CI job (which runs `go test -v -cover -race`) can be bypassed when merging PRs.

This PR adds a `workflow_dispatch`-only workflow that sets `test` as a required status check via the GitHub API.

**To apply the fix:** after merging this PR, go to Actions → `configure-branch-protection` → Run workflow.

## Change

- `.github/workflows/configure-branch-protection.yml` — manual-trigger workflow with `administration: write` permission
- `scripts/configure-branch-protection.sh` — applies `required_status_checks: contexts: [test]` via `gh api`

## Verification

- `go vet ./...`: no issues
- `go test ./...`: pass
- `shellcheck scripts/configure-branch-protection.sh`: no issues
- `staticcheck ./...`: 0 findings