### PR TITLE
Reject missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ cmd_cache --file depedingfile.go --env GOPATH -- go build
 cmd_cache
 
 Usage:
- cmd_cache [--cache-directory=DIRECTORY] [--max-cache-entries=COUNT] [(--file FILE | --env ENV | --text TEXT)...] -- [COMMAND...]
+ cmd_cache [--cache-directory=DIRECTORY] [--max-cache-entries=COUNT] [(--file FILE | --env ENV | --text TEXT)...] -- COMMAND...
  cmd_cache (--help | --version)
 
 Arguments:

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 
 const COMMAND_USAGE = `cmd_cache
 Usage:
- cmd_cache [--cache-directory=DIRECTORY] [--max-cache-entries=COUNT] [(--file FILE | --env ENV | --text TEXT)...] -- [COMMAND...]
+ cmd_cache [--cache-directory=DIRECTORY] [--max-cache-entries=COUNT] [(--file FILE | --env ENV | --text TEXT)...] -- COMMAND...
  cmd_cache (--help | --version)
 
 Arguments:
@@ -518,10 +518,15 @@ var version string
 var exit = os.Exit
 
 func main() {
-	opts, err := docopt.ParseDoc(COMMAND_USAGE)
+	parser := &docopt.Parser{HelpHandler: docopt.PrintHelpOnly}
+	opts, err := parser.ParseArgs(COMMAND_USAGE, nil, "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit(1)
+		return
+	}
+	if opts == nil {
+		return
 	}
 	if showVersion, _ := opts.Bool("--version"); showVersion {
 		fmt.Println(version)
@@ -539,6 +544,11 @@ func main() {
 	}
 
 	commands := opts["COMMAND"].([]string)
+	if len(commands) == 0 {
+		fmt.Fprintln(os.Stderr, "COMMAND is required")
+		exit(1)
+		return
+	}
 	commandContext := CommandContext{
 		Command:                  commands,
 		Texts:                    opts["TEXT"].([]string),

--- a/main_test.go
+++ b/main_test.go
@@ -42,6 +42,16 @@ func TestDocopt(t *testing.T) {
 	}
 }
 
+func TestDocoptRejectsMissingCommand(t *testing.T) {
+	parser := &docopt.Parser{HelpHandler: docopt.NoHelpHandler}
+	_, err := parser.ParseArgs(COMMAND_USAGE, []string{
+		"--file", "test.txt", "--",
+	}, "")
+	if err == nil {
+		t.Fatal("docopt accepted a missing command")
+	}
+}
+
 func TestVersion(t *testing.T) {
 	_, err := docopt.ParseArgs(COMMAND_USAGE, []string{
 		"--version",
@@ -70,6 +80,37 @@ func TestMainWritesVersionToStdout(t *testing.T) {
 	}
 	if output != "1.2.3-test\n" {
 		t.Fatalf("stdout = %q, want %q", output, "1.2.3-test\n")
+	}
+}
+
+func TestMainRejectsMissingCommand(t *testing.T) {
+	originalExit := exit
+	defer func() {
+		exit = originalExit
+	}()
+	originalArgs := os.Args
+	defer func() {
+		os.Args = originalArgs
+	}()
+
+	os.Args = []string{"cmd_cache", "--cache-directory=" + t.TempDir(), "--"}
+	exit = func(code int) {
+		panic(testExitCode(code))
+	}
+
+	output, recovered := captureStderrDuring(t, main)
+	code, ok := recovered.(testExitCode)
+	if !ok {
+		t.Fatalf("main() recovered %v, want exit code panic", recovered)
+	}
+	if code != 1 {
+		t.Fatalf("unexpected exit code: %d", code)
+	}
+	if strings.Contains(output, "panic") || strings.Contains(output, "index out of range") {
+		t.Fatalf("stderr = %q, must not contain panic details", output)
+	}
+	if !strings.Contains(output, "Usage:") && !strings.Contains(output, "COMMAND") {
+		t.Fatalf("stderr = %q, want usage or missing command error", output)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Require a wrapped command in the CLI usage.
- Route invalid command-line input through the main error path instead of letting the parser exit the process.
- Add regression coverage for missing-command handling.

## Verification
- `gofmt -w main.go main_test.go`
- `go install`
- `shellcheck bin/*.sh`
- `go vet ./...`
- `go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `docker buildx build --file docker/server/Dockerfile --platform linux/amd64,linux/arm64 --tag cmd_cache:pr-check --progress=plain .`
- `git diff --check`
- `check-pr-collateral` (0 violations, 0 advisories)
- implement-validator foreground gate: `overall: pass`
