### PR TITLE
Pin Docker base image digests in docker/server/Dockerfile

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS build
 
 WORKDIR /src
 
@@ -13,7 +13,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /out/cmd_cache .
 
-FROM alpine:3.22
+FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
 
 COPY --from=build /out/cmd_cache /usr/local/bin/cmd_cache
 


### PR DESCRIPTION
## What

Pins both `FROM` instructions in `docker/server/Dockerfile` to their current SHA256 digest.

```dockerfile
# Before
FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
FROM alpine:3.22

# After
FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS build
FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
```

## Why

Mutable tags (`golang:1.26-alpine`, `alpine:3.22`) can silently point to different image layers after a registry update. Pinning the digest ensures:

- **Reproducibility**: every build pulls the exact same base image regardless of when it runs.
- **Supply-chain integrity**: a compromised or replaced tag on Docker Hub cannot inject unexpected layers into the build.

GitHub Actions references are already commit-SHA pinned in this repo. This change brings Docker base images to the same standard.

## Trade-offs

Digests must be updated when a new patch release of the base image is desired. Renovate or Dependabot can automate this update. Version tags are kept alongside the digest for human readability.

## Verification

- `go vet ./...`: pass
- `gofmt -l .`: no unformatted files
- Dockerfile syntax unchanged; only `@sha256:...` appended to each `FROM`