### PR TITLE
Clarify zero pruning semantics

### DIFF
--- a/main.go
+++ b/main.go
@@ -491,8 +491,8 @@ func collectCompleteCacheEntries(cacheDirectory string) ([]cacheEntry, error) {
 }
 
 func pruneCacheEntries(cacheDirectory string, maxEntries int) error {
-	if maxEntries <= 0 {
-		return nil
+	if maxEntries < 0 {
+		return fmt.Errorf("maxEntries must be non-negative: %d", maxEntries)
 	}
 
 	entries, err := collectCompleteCacheEntries(cacheDirectory)
@@ -565,8 +565,10 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	if pruneErr := pruneCacheEntries(cacheDirectory, maxCacheEntries); pruneErr != nil {
-		fmt.Fprintln(os.Stderr, pruneErr)
+	if maxCacheEntries > 0 {
+		if pruneErr := pruneCacheEntries(cacheDirectory, maxCacheEntries); pruneErr != nil {
+			fmt.Fprintln(os.Stderr, pruneErr)
+		}
 	}
 	exit(exitStatus)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -772,6 +772,39 @@ func TestMainRejectsInvalidMaxCacheEntries(t *testing.T) {
 	}
 }
 
+func TestMainMaxCacheEntriesZeroDisablesPruning(t *testing.T) {
+	originalExit := exit
+	defer func() {
+		exit = originalExit
+	}()
+	originalArgs := os.Args
+	defer func() {
+		os.Args = originalArgs
+	}()
+
+	cacheDirectory := t.TempDir()
+	exit = func(code int) {
+		if code != 0 {
+			panic(testExitCode(code))
+		}
+	}
+
+	for _, text := range []string{"first", "second"} {
+		os.Args = []string{"cmd_cache", "--cache-directory=" + cacheDirectory, "--max-cache-entries=0", "--text", text, "--", "sh", "-c", "echo " + text}
+		if _, recovered := captureStdoutDuring(t, main); recovered != nil {
+			t.Fatalf("main() recovered %v, want nil", recovered)
+		}
+	}
+
+	entries, err := collectCompleteCacheEntries(cacheDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("complete entries = %d, want 2", len(entries))
+	}
+}
+
 func TestPruneCacheEntriesRemovesOldestCompleteEntries(t *testing.T) {
 	cacheDirectory := t.TempDir()
 	oldTime := time.Unix(100, 0)
@@ -820,7 +853,7 @@ func TestPruneCacheEntriesIgnoresIncompleteEntries(t *testing.T) {
 	assertPartialCacheEntryExists(t, cacheDirectory, incompleteKey)
 }
 
-func TestPruneCacheEntriesDisabledKeepsCompleteEntries(t *testing.T) {
+func TestPruneCacheEntriesZeroRemovesCompleteEntries(t *testing.T) {
 	cacheDirectory := t.TempDir()
 	oldKey := "0000000000000000000000000000000000000001"
 	newKey := "0000000000000000000000000000000000000002"
@@ -831,8 +864,18 @@ func TestPruneCacheEntriesDisabledKeepsCompleteEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertCacheEntryExists(t, cacheDirectory, oldKey)
-	assertCacheEntryExists(t, cacheDirectory, newKey)
+	assertCacheEntryRemoved(t, cacheDirectory, oldKey)
+	assertCacheEntryRemoved(t, cacheDirectory, newKey)
+}
+
+func TestPruneCacheEntriesRejectsNegativeMaxEntries(t *testing.T) {
+	err := pruneCacheEntries(t.TempDir(), -1)
+	if err == nil {
+		t.Fatal("pruneCacheEntries returned nil error for negative maxEntries")
+	}
+	if !strings.Contains(err.Error(), "non-negative") {
+		t.Fatalf("error = %q, want non-negative validation", err)
+	}
 }
 
 func TestPruneCacheEntriesIgnoresNonCacheFileGroups(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat `pruneCacheEntries(..., 0)` as a zero-entry retention limit instead of a disabled-pruning sentinel.
- Keep the CLI contract unchanged: `--max-cache-entries=0` still disables pruning at the CLI boundary.
- Return an explicit error for negative `maxEntries` values passed directly to the pruning helper.

## Tests
- `go test -run 'Test(MainMaxCacheEntriesZeroDisablesPruning|PruneCacheEntries)' ./...`
- `go install && shellcheck bin/*.sh && go vet ./... && go mod tidy && git diff --exit-code -- go.mod go.sum && go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `actionlint .github/workflows/*.yml`
- `typos .`
- `docker build -f docker/server/Dockerfile .`

## Compatibility
- Existing CLI users can continue using `--max-cache-entries=0` to disable pruning.
