### PR TITLE
test: isolate filesystem test artifacts

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -299,17 +299,26 @@ func TestCommandOrderStillAffectsHash(t *testing.T) {
 }
 
 func TestFileHash(t *testing.T) {
-	outFile, err := os.OpenFile("build/testfile", os.O_WRONLY|os.O_CREATE, 0666)
-	if err != nil {
-		log.Fatal(err)
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	if err := os.Mkdir("build", 0755); err != nil {
+		t.Fatal(err)
 	}
-	outFile.Write([]byte("Hello, World!"))
+	dependencyFile := filepath.Join("build", "testfile")
+
+	outFile, err := os.OpenFile(dependencyFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer outFile.Close()
+	if _, err := outFile.Write([]byte("Hello, World!")); err != nil {
+		t.Fatal(err)
+	}
 	hashString := hashStringFromCommandContext(t, CommandContext{
 		Command:                  []string{},
 		Texts:                    []string{},
 		EnvironmentVariableNames: []string{},
-		Filenames:                []string{"build/testfile"},
+		Filenames:                []string{dependencyFile},
 	})
 	if hashString != "6d7e43ef5351becf7a79030cfa7325756176674b" {
 		t.Error("Unexpected hash value:", hashString)
@@ -423,12 +432,8 @@ func TestGetOrRunReplaysCacheOnHit(t *testing.T) {
 }
 
 func TestRunAndCacheTruncatesExistingCacheFiles(t *testing.T) {
-	cacheDirectory := ".cmd_cache_test"
+	cacheDirectory := t.TempDir()
 	cacheKey := "cache-key"
-	if err := os.MkdirAll(cacheDirectory, 0755); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(cacheDirectory)
 
 	commandCache := CommandCache{
 		Command:        []string{"sh", "-c", "printf x; printf y >&2"},


### PR DESCRIPTION
## Summary
- Keep the file-hash fixture inside a per-test temporary working directory.
- Use `t.TempDir()` for the cache truncation test instead of a fixed repository-relative directory.

## Validation
- `go test ./...`
- `go install && shellcheck bin/*.sh && go vet ./... && go mod tidy && git diff --exit-code -- go.mod go.sum && go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `docker buildx build --file docker/server/Dockerfile --platform linux/amd64,linux/arm64 --tag kitsuyui/cmd_cache:local-pr-check --label org.opencontainers.image.source=local --progress=plain .`
- `typos main_test.go`
