### PR TITLE
chore: remove vestigial build/ placeholder and gox build script

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-go get -d ./...
-CGO_ENABLED=0 \
-gox \
--ldflags '-w -s' \
--ldflags '-X main.version='"$BUILD_VERSION" \
--output='build/cmd_cache_{{.OS}}_{{.Arch}}'

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Summary

Remove the vestigial `build/` directory placeholder and the dead gox
cross-compile script `bin/build.sh`.

## Background

`bin/build.sh` used [gox](https://github.com/mitchellh/gox) to produce
cross-compiled binaries at `build/cmd_cache_{{.OS}}_{{.Arch}}`. When the
release flow migrated to goreleaser (`.github/workflows/release.yml`),
`build/` and `bin/build.sh` were left behind.

`build/` had been kept as a git placeholder (via `build/.gitignore`) because
`TestFileHash` in `main_test.go` previously opened `build/testfile` directly.
That dependency was removed by `test: isolate filesystem test artifacts`
(commit 325792f), which switched the test to `t.TempDir()`.

After that fix, nothing in the repository depends on `build/` or
`bin/build.sh`.

## Changes

- `build/.gitignore` removed — the directory is no longer tracked
- `bin/build.sh` removed — superseded by goreleaser; unreferenced since the
  migration

## Verification

- `go test ./...` passes with no changes to test logic
- `go vet ./...` passes
- `staticcheck ./...` passes with 0 findings
- `shellcheck` passes on remaining `bin/*.sh` scripts
