### PR TITLE
Guard mux frame length encoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,12 +146,25 @@ type muxWriter struct {
 	stream byte // 1 = stdout, 2 = stderr
 }
 
+const maxMuxFramePayloadLength uint64 = 1<<32 - 1
+
+func muxFrameHeader(stream byte, payloadLength uint64) ([5]byte, error) {
+	var header [5]byte
+	if payloadLength > maxMuxFramePayloadLength {
+		return header, fmt.Errorf("mux frame payload too large: %d bytes exceeds %d-byte frame limit", payloadLength, maxMuxFramePayloadLength)
+	}
+	header[0] = stream
+	binary.BigEndian.PutUint32(header[1:], uint32(payloadLength))
+	return header, nil
+}
+
 func (m *muxWriter) Write(p []byte) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	var header [5]byte
-	header[0] = m.stream
-	binary.BigEndian.PutUint32(header[1:], uint32(len(p)))
+	header, err := muxFrameHeader(m.stream, uint64(len(p)))
+	if err != nil {
+		return 0, err
+	}
 	if _, err := m.w.Write(header[:]); err != nil {
 		return 0, err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -718,6 +718,24 @@ func TestRunAndCacheCreatesMuxFileAndReplayPreservesStreams(t *testing.T) {
 	}
 }
 
+func TestMuxFrameHeaderEncodesMaxPayloadLength(t *testing.T) {
+	header, err := muxFrameHeader(2, maxMuxFramePayloadLength)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := [5]byte{2, 0xff, 0xff, 0xff, 0xff}
+	if header != expected {
+		t.Fatalf("muxFrameHeader() = %v, want %v", header, expected)
+	}
+}
+
+func TestMuxFrameHeaderRejectsOversizedPayload(t *testing.T) {
+	_, err := muxFrameHeader(1, maxMuxFramePayloadLength+1)
+	if err == nil {
+		t.Fatal("muxFrameHeader() accepted a payload larger than the uint32 frame limit")
+	}
+}
+
 func TestReplayByCacheFallsBackToSequentialWithoutMuxFile(t *testing.T) {
 	cacheDirectory := t.TempDir()
 	cacheKey := "no-mux-test"


### PR DESCRIPTION
## Summary

- Add a mux frame header helper that rejects payload lengths larger than the uint32 frame limit.
- Cover the maximum encodable frame length and oversized rejection without allocating a large buffer.

## Tests

- `go test -run 'TestMuxFrameHeader' -v ./...`
- `go install`
- `shellcheck bin/*.sh`
- `go vet ./...`
- `go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `gofmt -l main.go main_test.go`
- `git diff --check`
